### PR TITLE
Fix for payment amount in payment table

### DIFF
--- a/app/Http/Controllers/Finance/ReportsController.php
+++ b/app/Http/Controllers/Finance/ReportsController.php
@@ -94,11 +94,7 @@ class ReportsController extends Controller
             'bankServiceTaxForex' => 0,
         ];
         foreach (config('constants.currency') as $currency => $currencyMeta) {
-            $report['sentAmount'][$currency] = 0;
-            $report['paidAmount'][$currency] = [
-                'converted' => 0,
-                'default' => 0,
-            ];
+            $report['totalSentAmount'][$currency] = 0;
             $report['bankCharges'][$currency] = 0;
             $report['dueAmount'][$currency] = 0;
             $report['receivable'][$currency] = 0;
@@ -107,7 +103,7 @@ class ReportsController extends Controller
 
         foreach ($sentInvoices as $invoice) {
             $report['gst'] += $invoice->gst;
-            $report['sentAmount'][$invoice->currency] += $invoice->amount;
+            $report['totalSentAmount'][$invoice->currency] += $invoice->amount;
 
             if (!$invoice->payments->count()) {
                 $report['receivable'][$invoice->currency] += $invoice->amount;
@@ -117,16 +113,7 @@ class ReportsController extends Controller
         foreach ($paidInvoices as $invoice) {
             $report['totalPayments'] += $invoice->payments->count();
             foreach ($invoice->payments as $payment) {
-                $paidAmount = $payment->amount;
-                $report['paidAmount'][$payment->currency]['default'] += $paidAmount;
-
-                if ($payment->currency != 'INR') {
-                    $conversionRate = $payment->conversion_rate ?? 1;
-                    $paidAmount = $payment->amount * $conversionRate;
-                    $report['paidAmount'][$payment->currency]['converted'] += $paidAmount;
-                }
-
-                $report['totalPaidAmount'] += $paidAmount;
+                $report['totalPaidAmount'] += $payment->amount;
                 $report['tds'] += $payment->tds;
 
                 $report['bankCharges'][$payment->currency] += $payment->bank_charges;

--- a/resources/views/finance/reports/index.blade.php
+++ b/resources/views/finance/reports/index.blade.php
@@ -52,8 +52,8 @@
             <div class="row">
                 <div class="col-md-4">
                     <h4>Invoiced amount</h4>
-                    @foreach ($report['sentAmount'] as $currency => $sentAmount)
-                        <h5 id="sent_amount_{{ $currency }}" data-sent-amount="{{ $sentAmount }}"><b>{{ $currency }} : </b>{{ config('constants.currency.' . $currency . '.symbol') }}&nbsp;{{ $sentAmount }}</h5>
+                    @foreach ($report['totalSentAmount'] as $currency => $totalSentAmount)
+                        <h5 id="sent_amount_{{ $currency }}" data-sent-amount="{{ $totalSentAmount }}"><b>{{ $currency }} : </b>{{ config('constants.currency.' . $currency . '.symbol') }}&nbsp;{{ $totalSentAmount }}</h5>
                         @if($currency == 'USD')
                             <h6>Est rate USD to INR:&nbsp;<input type="number" class="form-control form-control-sm d-inline w-25" placeholder="rate" v-model="conversionRateUSD" id="conversion_rate_usd" min="0" step="0.01" data-conversion-rate-usd="{{ config('constants.finance.conversion-rate-usd-to-inr') }}"></h6>
                             <h6>Est amount USD to INR:&nbsp;{{ config('constants.currency.INR.symbol') }}&nbsp;<span>@{{ convertedUSDSentAmount }}</span></h6>
@@ -158,8 +158,11 @@
                                 <td>{{ date(config('constants.display_date_format'), strtotime($payment->paid_at)) }}</td>
                                 <td>
                                     @php
-                                        $type = $payment->currency != 'INR' ? 'converted' : 'default';
-                                        $paidAmount = $report['paidAmount'][$payment->currency][$type];
+                                        $paidAmount = $payment->amount;
+                                        if ($payment->currency != 'INR') {
+                                            $conversionRate = $payment->conversion_rate ?? 1;
+                                            $paidAmount = $payment->amount * $conversionRate;
+                                        }
                                     @endphp
                                     {{ config("constants.currency.$payment->currency.symbol") }}&nbsp;{{ number_format((float)$paidAmount, 2, '.', '') }}
                                 </td>


### PR DESCRIPTION
Changes include:

1. Removing `paidAmount` calculation in ReportsController. Not needed anymore.
2. Renaming `sentAmount` to `totalsentAmount` since it is actually representing the latter one.