### PR TITLE
added check for currency-exchange-rate api key present in the env

### DIFF
--- a/Modules/Invoice/Config/config.php
+++ b/Modules/Invoice/Config/config.php
@@ -9,7 +9,7 @@ return [
     ],
 
     'default-date-format' => 'd M Y',
-
+    
     'mail' => [
         'unpaid-invoice' => [
             'email' => env('INVOICE_UNPAID_LIST_EMAIL', 'finance@coloredcow.com'),

--- a/Modules/Invoice/Config/config.php
+++ b/Modules/Invoice/Config/config.php
@@ -9,7 +9,7 @@ return [
     ],
 
     'default-date-format' => 'd M Y',
-    
+
     'mail' => [
         'unpaid-invoice' => [
             'email' => env('INVOICE_UNPAID_LIST_EMAIL', 'finance@coloredcow.com'),

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -33,6 +33,10 @@ class CurrencyService implements CurrencyServiceContract
 
     private function fetchExchangeRateInINR()
     {
+        if(!config('services.currencylayer.access_key')){
+            return round(config('services.currencylayer.default_rate'),2);
+        }
+
         $response = $this->client->get('live', [
             'query' => [
                 'access_key' => config('services.currencylayer.access_key'),

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -33,7 +33,7 @@ class CurrencyService implements CurrencyServiceContract
 
     private function fetchExchangeRateInINR()
     {
-        if(!config('services.currencylayer.access_key')) {
+        if (!config('services.currencylayer.access_key')) {
             return round(config('services.currencylayer.default_rate'), 2);
         }
 

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -33,8 +33,8 @@ class CurrencyService implements CurrencyServiceContract
 
     private function fetchExchangeRateInINR()
     {
-        if(!config('services.currencylayer.access_key')){
-            return round(config('services.currencylayer.default_rate'),2);
+        if(!config('services.currencylayer.access_key')) {
+            return round(config('services.currencylayer.default_rate'), 2);
         }
 
         $response = $this->client->get('live', [

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -33,7 +33,7 @@ class CurrencyService implements CurrencyServiceContract
 
     private function fetchExchangeRateInINR()
     {
-        if (!config('services.currencylayer.access_key')) {
+        if (! config('services.currencylayer.access_key')) {
             return round(config('services.currencylayer.default_rate'), 2);
         }
 

--- a/config/services.php
+++ b/config/services.php
@@ -42,6 +42,7 @@ return [
     ],
 
     'currencylayer' => [
-        'access_key' => env('CURRENCYLAYER_API_KEY')
+        'access_key' => env('CURRENCYLAYER_API_KEY'),
+        'default_rate' => env('DEFAULT_RATE_USDINR')
     ]
 ];


### PR DESCRIPTION
Targets #998 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->

<!--- Please complete the following steps and check these boxes before filing your PR: -->

### Description
<!--- Describe your changes in detail -->
<!--- Why these changes are required? What existing problem does the pull request solve? -->
It fixes the issue 998, added the check whether the api key is present in the config or env, if it's not present, then the function returns a default value (configurable from env) 
### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
