### PR TITLE
Bugfix nonvalidation for previous start_date in update form 

### DIFF
--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -15,7 +15,7 @@
     <br><br>
     @include('status', ['errors' => $errors->all()])
     <h2 class="mb-3">Edit Opportunity</h2>
-    <form action="{{ $formAction }}" method="POST" id="update-form" novalidate>
+    <form action="{{ $formAction }}" method="POST" id="update-form">
         @csrf
         @method('PATCH')
         <div class="card mb-3">
@@ -59,7 +59,7 @@
                     </div>
                     <div class="col-md-3 form-group">
                         <label for="start_date" class="fz-14 leading-none text-secondary mb-1">Start Date</label>
-                        <input type="date" class="form-control" id="job_start_date" name="start_date" value="{{ old('start_date', $job->start_date) }}">     
+                        <input type="date" class="form-control" id="jobs_start_date" name="start_date" min="{{ old('start_date', $job->start_date) }}" value="{{ old('start_date', $job->start_date) }}">     
                     </div>
                     <div class="col-md-3 form-group">
                         <label for="end_date" class="fz-14 leading-none text-secondary mb-1">End Date</label>

--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -15,7 +15,7 @@
     <br><br>
     @include('status', ['errors' => $errors->all()])
     <h2 class="mb-3">Edit Opportunity</h2>
-    <form action="{{ $formAction }}" method="POST" id="update-form">
+    <form action="{{ $formAction }}" method="POST" id="update-form" novalidate>
         @csrf
         @method('PATCH')
         <div class="card mb-3">


### PR DESCRIPTION
Targets #{1019}

Checklist:

- [x]  The date validation should not be when there is already an existing date.

- [ ]  The validation should only work if the job opportunity didn't have a date before.