### PR TITLE
Removed subsheet id support

### DIFF
--- a/Modules/Project/Console/SyncEffortsheet.php
+++ b/Modules/Project/Console/SyncEffortsheet.php
@@ -53,22 +53,17 @@ class SyncEffortsheet extends Command
             }
 
             $matchesId = [];
-            $matchesSheetId = [];
-
             $matchesSheetId = preg_match('/.*[^-\w]([-\w]{25,})[^-\w]?.*/', $effortSheetURL, $matchesId);
-            $matchesSubsheetId = preg_match('/gid=([0-9]+)/', $effortSheetURL, $matchesSheetId);
 
-            if (! $matchesSheetId || ! $matchesSubsheetId) {
+            if (! $matchesSheetId) {
                 continue;
             }
 
             $sheetId = $matchesId[1];
-            $subSheetID = $matchesSheetId[1];
             $sheet = new Sheets();
             $projectMembersCount = $project->teamMembers()->count();
             $range = 'C2:G' . ($projectMembersCount + 1); // this will depend on the number of people on the project
             $sheets = $sheet->spreadsheet($sheetId)
-                            ->sheetById($subSheetID)
                             ->range($range)
                             ->get();
 
@@ -77,6 +72,13 @@ class SyncEffortsheet extends Command
                 $portalUser = $users->where('nickname', $userNickname)->first();
 
                 if (! $portalUser) {
+                    continue;
+                }
+
+                $projectMonth = Carbon::create($user[1])->month;
+                $currentMonth = now()->month;
+
+                if ($projectMonth !== $currentMonth) {
                     continue;
                 }
 


### PR DESCRIPTION
Targets #1008

### Description

- This PR removes the subsheetID as the latest ID from the google sheet is always picked up. 
- Added check if the sheet is of the current month or not

### Checklist:

- [x] I have performed a self-review of my own code.
