### PR TITLE
Fix for issue #1328

### DIFF
--- a/Modules/Invoice/Resources/views/tax-report.blade.php
+++ b/Modules/Invoice/Resources/views/tax-report.blade.php
@@ -61,7 +61,7 @@
                         @if (request()->input('region') == config('invoice.region.indian'))
                             <td>{{ $invoice->invoiceAmount() }}</td>
                             <td>{{ $invoice->gst }}</td>
-                            <td>{{ number_format($invoice->tds, 2) }}</td>
+                            <td>{{ number_format((float)$invoice->tds, 2) }}</td>
                         @endif
                         @if (request()->input('region') == config('invoice.region.international'))
                             <td>{{ $invoice->bank_charges }}</td>
@@ -70,7 +70,7 @@
                         @if(request()->input('region') == '')
                             <td>{{ $invoice->invoiceAmount() }}</td>
                             <td>{{ $invoice->gst }}</td>
-                            <td>{{ number_format($invoice->tds, 2) }}</td>
+                            <td>{{ number_format((float)$invoice->tds, 2) }}</td>
                             <td>{{ $invoice->bank_charges }}</td>
                             <td>{{ $invoice->conversion_rate_diff }}</td>
                         @endif

--- a/Modules/Invoice/Services/InvoiceService.php
+++ b/Modules/Invoice/Services/InvoiceService.php
@@ -213,7 +213,7 @@ class InvoiceService implements InvoiceServiceContract
                 'GST' => $invoice->gst,
                 'Amount (+GST)' => (float) str_replace(['$', '₹'], '', $invoice->invoiceAmount()),
                 'Received amount' => $invoice->amount_paid,
-                'TDS' => number_format($invoice->tds, 2),
+                'TDS' => number_format((float)$invoice->tds, 2),
                 'Sent at' => $invoice->sent_on->format(config('invoice.default-date-format')),
                 'Payment at' => $invoice->payment_at ? $invoice->payment_at->format(config('invoice.default-date-format')) : '-',
                 'Status' => Str::studly($invoice->status)
@@ -250,7 +250,7 @@ class InvoiceService implements InvoiceServiceContract
                 'Bank Charges' => $invoice->bank_charges,
                 'Conversion Rate Diff' => $invoice->conversion_rate_diff,
                 'Conversion Rate' => $invoice->conversion_rate,
-                'TDS' => number_format($invoice->tds, 2),
+                'TDS' => number_format((float)$invoice->tds, 2),
                 'Sent at' => $invoice->sent_on->format(config('invoice.default-date-format')),
                 'Payment at' => $invoice->payment_at ? $invoice->payment_at->format(config('invoice.default-date-format')) : '-',
                 'Status' => Str::studly($invoice->status)

--- a/Modules/Invoice/Services/InvoiceService.php
+++ b/Modules/Invoice/Services/InvoiceService.php
@@ -213,7 +213,7 @@ class InvoiceService implements InvoiceServiceContract
                 'GST' => $invoice->gst,
                 'Amount (+GST)' => (float) str_replace(['$', '₹'], '', $invoice->invoiceAmount()),
                 'Received amount' => $invoice->amount_paid,
-                'TDS' => number_format((float)$invoice->tds, 2),
+                'TDS' => number_format((float) $invoice->tds, 2),
                 'Sent at' => $invoice->sent_on->format(config('invoice.default-date-format')),
                 'Payment at' => $invoice->payment_at ? $invoice->payment_at->format(config('invoice.default-date-format')) : '-',
                 'Status' => Str::studly($invoice->status)
@@ -250,7 +250,7 @@ class InvoiceService implements InvoiceServiceContract
                 'Bank Charges' => $invoice->bank_charges,
                 'Conversion Rate Diff' => $invoice->conversion_rate_diff,
                 'Conversion Rate' => $invoice->conversion_rate,
-                'TDS' => number_format((float)$invoice->tds, 2),
+                'TDS' => number_format((float) $invoice->tds, 2),
                 'Sent at' => $invoice->sent_on->format(config('invoice.default-date-format')),
                 'Payment at' => $invoice->payment_at ? $invoice->payment_at->format(config('invoice.default-date-format')) : '-',
                 'Status' => Str::studly($invoice->status)


### PR DESCRIPTION
Targets #1328
<!--- If there is an open issue, please link to the issue here by replacing [#1328 ]-->


### Description
<!--- Describe your changes in detail -->
The value of tax variable which is obtained in number_format() function  is typecast to float.

<!--- Why these changes are required? What existing problem does the pull request solve? -->

Inumber_format() fetch value of tax upto 2  decimal places. In a scenario where the tax vale is 0 or 2.1 (i.e having value of having only one decimal places). The following error occurs 
non well formed numeric value encountered 

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [* ] I have performed a self-review of my own code.
- [*] I have tested code changes in UAT environment
