### PR TITLE
Added badge for primary project while invoice creation

### DIFF
--- a/Modules/Client/Entities/Client.php
+++ b/Modules/Client/Entities/Client.php
@@ -46,7 +46,7 @@ class Client extends Model
 
     public function projectLevelBillingProjects()
     {
-        return $this->hasMany(Project::class)->where('projects.status', '!=', 'inactive')
+        return $this->hasMany(Project::class)->select('projects.*')->where('projects.status', '!=', 'inactive')
             ->leftJoin('project_meta', function ($join) {
                 $join->on('project_meta.project_id', '=', 'projects.id');
                 $join->where('project_meta.key', '=', config('project.meta_keys.billing_level.value.project.key'));
@@ -55,10 +55,11 @@ class Client extends Model
 
     public function clientLevelBillingProjects()
     {
-        return $this->belongsToMany(Project::class, 'project_meta', 'projects.client_id', 'project_id')->where([
-            'project_meta.key' => config('project.meta_keys.billing_level.key'),
-            'project_meta.value' => config('project.meta_keys.billing_level.value.client.key')
-        ])->where('projects.status', '!=', 'inactive');
+        return $this->hasMany(Project::class)->select('projects.*')->where('projects.status', '!=', 'inactive')
+            ->leftJoin('project_meta', function ($join) {
+                $join->on('project_meta.project_id', '=', 'projects.id');
+                $join->where('project_meta.key', '=', config('project.meta_keys.billing_level.value.client.key'));
+            });
     }
 
     public function getReferenceIdAttribute()

--- a/Modules/Invoice/Resources/views/subviews/create/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/create/invoice-details.blade.php
@@ -28,6 +28,7 @@
                             >
                                 <i class="fa fa-question-circle"></i>&nbsp;
                             </span>
+                            <span class="badge badge-warning" v-if="client && !primaryProject">{{ _('No primary project for this client.') }}</span>
                         </div>
                     </div>
                     <select name="billing_for" id="billing_for" class="form-control" required="required">


### PR DESCRIPTION
### Changes
- If a client don't have a primary project then we should show a warning that no primary project set for the client while creating invoice
- Corrected calculation to fetch the project level billing and client level billing projects for the client