### PR TITLE
Fixed functionality to mark an application on hold and send an email to the candidate

### DIFF
--- a/Modules/HR/Database/Seeders/SettingsTableSeeder.php
+++ b/Modules/HR/Database/Seeders/SettingsTableSeeder.php
@@ -64,5 +64,15 @@ class SettingsTableSeeder extends Seeder
             'setting_key' => 'applicant_verification_body',
             'setting_value' => '<div>Hello |*applicant_name*|,<br /><br /></div><p class="p1" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 1rem; color: #212529; font-family: Raleway, sans-serif; font-size: 14.4px; white-space: pre-wrap;">For verify the application, click on the below link <a style="box-sizing: border-box; color: #007bff; text-decoration-line: none; background-color: transparent;" href="|*verification_link*|">Verification link/</a></p>HR Team<br />ColoredCow</div>',
         ]);
+        Setting::updateOrCreate([
+            'module' => 'hr',
+            'setting_key' => 'application_on_hold_subject',
+            'setting_value' => 'Your application is put on hold',
+        ]);
+        Setting::updateOrCreate([
+            'module' => 'hr',
+            'setting_key' => 'application_on_hold_body',
+            'setting_value' => '<div>Dear |*applicant_name*|,</div><div> </div><div>Thanks for applying to ColoredCow for the position |*job_title*|.We don\'t have a relevant opening for the position right now. Your application is kept under waiting and we will reach out to you if there are any possibilities we can explore together. </div><div>Thanks,</div><div> </div><div>HR Team,</div><div>ColoredCow</div> ',
+        ]);
     }
 }

--- a/Modules/HR/Emails/Recruitment/Applicant/OnHold.php
+++ b/Modules/HR/Emails/Recruitment/Applicant/OnHold.php
@@ -42,7 +42,7 @@ class OnHold extends Mailable
      */
     public function build()
     {
-        return $this->from("amanbahuguna009@gmail.com")
+        return $this->from(config('hr.default.email'), config('hr.default.name'))
             ->subject($this->subject)
             ->view('mail.plain')->with([
             'body' => $this->body,

--- a/Modules/HR/Emails/Recruitment/Applicant/OnHold.php
+++ b/Modules/HR/Emails/Recruitment/Applicant/OnHold.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\HR\Emails\Recruitment\Applicant;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class OnHold extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * The mail subject.
+     *
+     * @var string
+     */
+    public $subject;
+
+    /**
+     * The mail body.
+     *
+     * @var string
+     */
+    public $body;
+
+    /**
+     * Create new message instance.
+     *
+     * @return void
+     */
+    public function __construct($subject, $body)
+    {
+        $this->subject = $subject;
+        $this->body = $body;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from("amanbahuguna009@gmail.com")
+            ->subject($this->subject)
+            ->view('mail.plain')->with([
+            'body' => $this->body,
+        ]);
+    }
+}

--- a/Modules/HR/Entities/Application.php
+++ b/Modules/HR/Entities/Application.php
@@ -357,6 +357,11 @@ class Application extends Model
         $this->update(['status' => config('hr.status.approved.label')]);
     }
 
+    public function onHold()
+    {
+        $this->update(['status' => config('hr.status.on-hold.label')]);
+    }
+
     public function onboarded()
     {
         $this->update(['status' => config('hr.status.onboarded.label')]);

--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -170,11 +170,9 @@ class ApplicationRound extends Model
                 $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
                 $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
 
-                Mail::to($applicant->email, $applicant->name)
-                    ->send(new OnHold($subject->setting_value, $body->setting_value));
+                Mail::to($applicant->email, $applicant->name)->send(new OnHold($subject->setting_value, $body->setting_value));
 
                 return redirect()->route('applications.job.index');
-                break;
 
             case 'send-for-approval':
                 $application->untag('new-application');

--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -150,31 +150,30 @@ class ApplicationRound extends Model
                 break;
 
             case 'on-hold':
-                    $application->untag('new-application');
-                    $application->untag('in-progress');
-                    $fillable['round_status'] = 'on-hold';
-                    $application->onHold();
+                $application->untag('new-application');
+                $application->untag('in-progress');
+                $fillable['round_status'] = 'on-hold';
+                $application->onHold();
 
-                    ApplicationMeta::create([
-                        'hr_application_id' => $application->id,
-                        'key' => 'on-hold',
-                        'value' => json_encode([
-                        'on-hold_by' => $fillable['conducted_person_id']])
-                        ]);
+                ApplicationMeta::create([
+                    'hr_application_id' => $application->id,
+                    'key' => 'on-hold',
+                    'value' => json_encode([
+                    'on-hold_by' => $fillable['conducted_person_id']])
+                    ]);
 
-                        $applicant = $application->applicant;
+                    $applicant = $application->applicant;
 
-                        $subject = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_subject')->first();
-                        $body = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_body')->first();
-                        $job_title = Job::find($application->hr_job_id)->title;
-                        $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
-                        $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
+                    $subject = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_subject')->first();
+                    $body = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_body')->first();
+                    $job_title = Job::find($application->hr_job_id)->title;
+                    $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
+                    $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
 
-                        Mail::to($applicant->email, $applicant->name)
-                            ->send(new OnHold($subject->setting_value, $body->setting_value));
+                    Mail::to($applicant->email, $applicant->name)
+                        ->send(new OnHold($subject->setting_value, $body->setting_value));
 
-                        return redirect()->route('applications.job.index');
-
+                    return redirect()->route('applications.job.index');
                     break;
 
             case 'send-for-approval':

--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -156,25 +156,25 @@ class ApplicationRound extends Model
                 $application->onHold();
 
                 ApplicationMeta::create([
-                    'hr_application_id' => $application->id,
-                    'key' => 'on-hold',
-                    'value' => json_encode([
-                    'on-hold_by' => $fillable['conducted_person_id']])
-                    ]);
+                'hr_application_id' => $application->id,
+                'key' => 'on-hold',
+                'value' => json_encode([
+                'on-hold_by' => $fillable['conducted_person_id']])
+                ]);
 
-                    $applicant = $application->applicant;
+                $applicant = $application->applicant;
 
-                    $subject = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_subject')->first();
-                    $body = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_body')->first();
-                    $job_title = Job::find($application->hr_job_id)->title;
-                    $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
-                    $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
+                $subject = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_subject')->first();
+                $body = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_body')->first();
+                $job_title = Job::find($application->hr_job_id)->title;
+                $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
+                $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
 
-                    Mail::to($applicant->email, $applicant->name)
-                        ->send(new OnHold($subject->setting_value, $body->setting_value));
+                Mail::to($applicant->email, $applicant->name)
+                    ->send(new OnHold($subject->setting_value, $body->setting_value));
 
-                    return redirect()->route('applications.job.index');
-                    break;
+                return redirect()->route('applications.job.index');
+                break;
 
             case 'send-for-approval':
                 $application->untag('new-application');

--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -13,6 +13,8 @@ use Modules\HR\Emails\Recruitment\SendForApproval;
 use Modules\HR\Emails\Recruitment\SendOfferLetter;
 use Modules\HR\Entities\Evaluation\ApplicationEvaluation;
 use Modules\User\Entities\User;
+use App\Models\Setting;
+use Modules\HR\Emails\Recruitment\Applicant\OnHold;
 use Modules\HR\Database\Factories\HrApplicationRoundFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -146,6 +148,34 @@ class ApplicationRound extends Model
                 $application->reject();
                 $applicant->applications->where('id', $attr['refer_to'])->first()->markInProgress();
                 break;
+
+            case 'on-hold':
+                    $application->untag('new-application');
+                    $application->untag('in-progress');
+                    $fillable['round_status'] = 'on-hold';
+                    $application->onHold();
+
+                    ApplicationMeta::create([
+                        'hr_application_id' => $application->id,
+                        'key' => 'on-hold',
+                        'value' => json_encode([
+                        'on-hold_by' => $fillable['conducted_person_id']])
+                        ]);
+
+                        $applicant = $application->applicant;
+
+                        $subject = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_subject')->first();
+                        $body = Setting::where('module', 'hr')->where('setting_key', 'application_on_hold_body')->first();
+                        $job_title = Job::find($application->hr_job_id)->title;
+                        $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
+                        $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
+
+                        Mail::to($applicant->email, $applicant->name)
+                            ->send(new OnHold($subject->setting_value, $body->setting_value));
+
+                        return redirect()->route('applications.job.index');
+
+                    break;
 
             case 'send-for-approval':
                 $application->untag('new-application');

--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -118,7 +118,7 @@ class ApplicationRound extends Model
             case 'reject':
                 $application->untag('new-application');
                 $fillable['round_status'] = 'rejected';
-                if (!empty($attr['follow_up_comment_for_reject'])) {
+                if (! empty($attr['follow_up_comment_for_reject'])) {
                     $this->followUps()->create([
                         'comments' => $attr['follow_up_comment_for_reject'],
                         'conducted_by' => auth()->id(),
@@ -214,7 +214,7 @@ class ApplicationRound extends Model
                 $subject = $attr['subject'];
                 $body = $attr['body'];
 
-                if (!$application->offer_letter) {
+                if (! $application->offer_letter) {
                     $application->offer_letter = FileHelper::generateOfferLetter($application);
                 }
                 Mail::send(new SendOfferLetter($application, $subject, $body));
@@ -443,7 +443,7 @@ class ApplicationRound extends Model
             return false;
         }
 
-        return is_null($this->round_status) || !$this->isOnboarded();
+        return is_null($this->round_status) || ! $this->isOnboarded();
     }
 
     public function getPreviousApplicationRound()

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -906,7 +906,7 @@
 														</button>
 													</div>
 													<div class="modal-body">
-														<p>Do you want to put your application on Hold?</p>
+														<p>Do you want to put this application on Hold?</p>
 													</div>
 													<div class="modal-footer">
 														<button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -2,933 +2,954 @@
 
 @section('content')
 <div :class="[showResumeFrame ? 'container-fluid' : 'container']" id="page_hr_applicant_edit">
-    <div class="row">
-        <div class="col-md-12">
-            <br>
-            @includeWhen($type == 'volunteer', 'hr.volunteers.menu')
-            @includeWhen($type == 'recruitment', 'hr.menu')
-            <br><br>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-3">
-            @include('hr.application.timeline', ['timeline' => $timeline, 'currentApplication' => $application])
-        </div>
-        <div v-bind:class="[showResumeFrame ? 'offset-md-2 col-md-7 pl-9' : 'col-md-8']">
-            <div class="card bg-transparent border-0">
-                @if(sizeOf($application->trialApplicationRounds))
-                    <nav>
-                        <div class="nav nav-pills" id="nav-tab" role="tablist">
-                            <a class="nav-item nav-link {{ $application->latestApplicationRound->round->isTrialRound() ? 'active' : '' }}" id="nav-trial-tab" data-toggle="tab" href="#nav-trial" role="tab" aria-controls="nav-trial" aria-selected="true">Trial</a>
-                            <a class="nav-item nav-link {{ $application->latestApplicationRound->round->isTrialRound() ? '' : 'active' }}" id="nav-pre-trial-tab" data-toggle="tab" href="#nav-pre-trial" role="tab" aria-controls="nav-pre-trial" aria-selected="false">Pre-Trial</a>
-                        </div>
-                    </nav>
-                    <div class="tab-content" id="nav-tabContent">
-                        <div class="tab-pane fade {{ $application->latestApplicationRound->round->isTrialRound() ? 'show active' : '' }}" id="nav-trial" role="tabpanel" aria-labelledby="nav-trial-tab">               
-                            <br>
-                            @foreach ($application->trialApplicationRounds as $applicationRound)
-                                @php
-                                    $applicationRoundReview = $applicationRound->applicationRoundReviews->where('review_key', 'feedback')->first();
-                                    $applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
-                                @endphp
-                                @if(sizeof($applicationRound->followUps))
-                                    <div class="my-2">
-                                    @foreach($applicationRound->followUps as $followUp)
-                                        <div class="d-flex align-items-center mb-1.5">
-                                            <i class="fa fa-clock-o fz-20 mr-1" aria-hidden="true"></i>
-                                            <span class="fz-14 leading-none">
-                                                <span class="mr-0.5">Followed up by</span>
-                                                <img src="{{ $followUp->conductedBy->avatar }}" class="w-20 h-20 rounded-circle mr-0.5" data-toggle="tooltip" title="{{ $followUp->conductedBy->name }}">
-                                                <span class="mr-1.5">on {{ $followUp->created_at->format(config('constants.full_display_date_format')) }}</span>
-                                                <a href="#" data-toggle="modal" data-target="#followUp{{$followUp->id}}">View feedback</a>
-                                                @include('hr::follow-up.modal')
-                                            </span>
-                                        </div>
-                                    @endforeach
-                                    </div>
-                                @endif
-                                @if ($loop->last && $applicationRound->application->hasTag('need-follow-up'))
-                                    <div class="d-flex justify-content-start">
-                                        <button type="button" class="btn btn-sm btn-info fz-14 leading-none text-white rounded-0 py-1" data-toggle="modal" data-target="#followUpModal">Follow up</button>
-                                    </div>
-                                    @include('hr.application.follow-up-modal')
-                                @endif
-                                <div class="card mb-3">
-                                    <div class="card-header d-flex align-items-center justify-content-between">
-                                        <div class="d-flex flex-column">
-                                            <div>
-                                                {{$applicationRound->trialRound->name }}
-                                                <span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
-                                                    <i class="fa fa-info-circle fa-lg"></i>
-                                                </span>
-                                            </div>
-                                            @if ($applicationRound->round_status)
-                                                <span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
-                                            @endif
-                                        </div>
-                                        <div class="d-flex align-items-center">
-                                            <div class="d-flex flex-column align-items-end">
-                                                @if ($applicationRound->noShow && $applicationRound->round->reminder_enabled)
-                                                    <span class="text-danger"><i class="fa fa-warning fa-lg"></i>&nbsp;{{ config('constants.hr.status.no-show-reminded.title') }}</span>
-                                                @endif
-                            
-                                                @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
-                                                    <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
-                                                @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
-                                                    <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
-                                                @endif
-                                                @if ($applicationRound->round_status && $applicationRound->conducted_date)
-                                                    <span>Conducted on: {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
-                                                @endif
-                                            </div>
-                                            <div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
-                                        </div>
-                                    </div>
-                                    <form action="/
-                                    hr/recruitment/applications/rounds/{{ $applicationRound->id }}" method="POST" enctype="multipart/form-data" class="applicant-round-form">
-                                        {{ csrf_field() }}
-                                        {{ method_field('PATCH') }}
-                                        <div id="collapse_{{ $loop->iteration }}" class="collapse {{ $application->latestApplicationRound->round->isTrialRound()? ($loop->last ? 'show' : '') : '' }}">
-                                            <div class="card-body">
-                                                @if ( !$applicationRound->round_status)
-                                                    <div class="form-row">
-                                                        <div class="form-group col-md-5">
-                                                            <label for="scheduled_date" class="fz-14 leading-none text-secondary w-100p">
-                                                                <div>
-                                                                <i class="fa fa-calendar" aria-hidden="true"></i>
-                                                                <span>Scheduled date</span>
-                                                                    @if($applicationRound->scheduled_date)
-                                                                        @if($applicationRound->hangout_link)
-                                                                            <a target="_blank" class="ml-5 font-muli-bold" href="{{ $applicationRound->hangout_link }}">
-                                                                                <i class="fa fa-video-camera" aria-hidden="true"></i>
-                                                                                <span>Meeting Link</span>
-                                                                            </a>
-                                                                        @endif
-                                                                    @endif
-                                                                </div>
-                                                            </label>
-                                                            @if ($applicationRound->scheduled_date)
-                                                                <input type="datetime-local" 
-                                                                    name="scheduled_date" id="scheduled_date" 
-                                                                    class="form-control form-control-sm" 
-                                                                    value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
-                                                            @else
-                                                                <div class="fz-16 leading-tight">Pending calendar confirmation</div>
-                                                            @endif
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <label for="scheduled_person_id" class="fz-14 leading-none text-secondary">
-                                                                <i class="fa fa-user" aria-hidden="true"></i>
-                                                                <span>Scheduled for</span>
-                                                            </label>
-                                                            @if ($applicationRound->scheduled_date)
-                                                                <select name="scheduled_person_id" id="scheduled_person_id" class="form-control form-control-sm" >
-                                                                    @foreach ($interviewers as $interviewer)
-                                                                        @php
-                                                                            $selected = $applicationRound->scheduled_person_id == $interviewer->id ? 'selected="selected"' : '';
-                                                                        @endphp
-                                                                        <option value="{{ $interviewer->id }}" {{ $selected }}>
-                                                                            {{ $interviewer->name }}
-                                                                        </option>
-                                                                    @endforeach
-                                                                </select>
-                                                            @else
-                                                                <div class="fz-16 leading-tight">
-                                                                    <img src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" class="w-25 h-25 rounded-circle">
-                                                                    <span>{{ $applicationRound->scheduledPerson->name }}</span>
-                                                                </div>
-                                                            @endif  
-                                                        </div>
-                                                        @if ($applicationRound->scheduled_date)
-                                                            <div class="form-group col-md-3 d-flex align-items-end">
-                                                                <button type="button" class="py-1 mb-0 btn btn-info btn-sm round-submit update-schedule" data-action="schedule-update">Update Schedule</button>
-                                                            </div>
-                                                        @endif
-                                                    </div>
-                                                @endif
-                                                @if($applicationRound->round->name == "Resume Screening")
-                                                    <div class="form-row">
-                                                        <div class="form-group col-md-12">
-                                                            <button type="button" class="btn btn-theme-fog btn-sm" @click="getApplicationEvaluation({{ $applicationRound->id }})">Application Evaluation</button>
-                                                        </div>
-                                                    </div>
-                                                @endif
-                                                <div class="form-row">
-                                                    <div class="form-group col-md-12">
-                                                        @php
-                                                            if ($loop->last && sizeOf($errors)) {
-                                                                $applicationRoundReviewValue = old('reviews.feedback');
-                                                            }
-                                                        @endphp
-                                                        <textarea name="reviews[{{ $applicationRound->id }}][feedback]" id="reviews[{{ $applicationRound->id }}][feedback]" rows="6" class="form-control" placeholder="Enter comments...">{{ $applicationRoundReviewValue }}</textarea>
-                                                    </div>
-                                                </div>
-                                                <div class="form-row d-flex justify-content-end">
-                                                    <button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
-                                                </div>
-                                            </div>
-                                            @php
-                                                $showFooter = false;
-                                                if ($loop->last && $application->latestApplicationRound->round->isTrialRound()) {
-                                                    if (in_array($applicationRound->application->status, [config('constants.hr.status.sent-for-approval.label'), 
-                                                    config('constants.hr.status.approved.label')])) {
-                                                        $showFooter = true;
-                                                    }
-                                                    elseif (in_array($applicationRound->round_status, [null, config('constants.hr.status.rejected.label')])) {
-                                                        $showFooter = true;
-                                                    }
-                                                }
-                                                elseif (!$applicationRound->mail_sent) {
-                                                    $showFooter = true;
-                                                }
-                                            @endphp
-                                            @if ($showFooter)
-                                            <div class="card-footer">
-                                                <div class="d-flex align-items-center">
-                                                    @if($application->latestApplicationRound->round->isTrialRound())
-                                                        @if ($applicationRound->showActions)
-                                                            <select name="action_type" id="action_type" 
-                                                            class="form-control w-50p" v-on:change="onSelectNextRound($event)" 
-                                                            data-application-job-rounds="{{ json_encode($application->job->trialRounds) }}">
-                                                                <option v-for="round in applicationJobRounds" value="round" 
-                                                                :data-next-round-id="round.id">Move to @{{ round.name }}</option>
-                                                                <option value="send-for-approval">Send for approval</option>
-                                                                <option value="approve">Approve</option>
-                                                                <option value="onboard">Onboard</option>
-                                                            </select>
-                                                            <button type="button" class="btn btn-success ml-2" @click="takeAction()">Take action</button>
-                                                        @endif
-                                                        @if ($loop->last && !$application->isRejected())
-                                                            {{-- @if ($applicantOpenApplications->count() > 1) --}}
-                                                                <button type="button" class="btn btn-outline-danger ml-2" id="rejectApplication" @click="rejectApplication()">Reject</button>
-                                                                @include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
-                                                            {{-- @else --}}
-                                                                {{-- <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject" data-toggle="modal" data-target="#application_reject_modal">Reject</button> --}}
-                                                            {{-- @endif --}}
-                                                        @endif
-                                                    @endif
-                                                    @if (!is_null($applicationRound->round_status) && !$applicationRound->mail_sent)
-                                                        <button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
-                                                    @endif
-                                                </div>
-                                            </div>
-                                            @endif
-                                        </div>
-                                        <input type="hidden" name="action" value="updated">
-                                        <input type="hidden" name="next_round" value="">
-                                        @if ($loop->last && $application->latestApplicationRound->round->isTrialRound())
-                                            <input type="hidden" name="current_applicationround_id" id="current_applicationround_id" value="{{ $applicationRound->id }}">
-                                        @endif
-                                        @includeWhen($applicationRound->showActions, 'hr.round-review-confirm-modal', 
-                                        ['applicationRound' => $applicationRound])
-                                        @if($application->latestApplicationRound->round->isTrialRound())
-                                            @includeWhen($loop->last, 'hr.application.send-for-approval-modal')
-                                            @includeWhen($loop->last, 'hr.application.onboard-applicant-modal')
-                                            @includeWhen($loop->last, 'hr.application.approve-applicant-modal')
-                                        @endif
-                                    </form>                          
-                                </div>
-                                @include('hr.round-guide-modal', ['round' => $applicationRound->round])
-                                @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
-                                @include('hr.application.application-evaluation', ['round' => $applicationRound->trialRound])
-                            @endforeach
-                        </div>
-                        <div class="tab-pane fade {{ $application->latestApplicationRound->round->isTrialRound() ? '' : 'show active' }}" id="nav-pre-trial" role="tabpanel" aria-labelledby="nav-pre-trial-tab">
-                            <br>
-                            @foreach ($application->applicationRoundsExceptTrial as $applicationRound)
-                                @php
-                                    $applicationRoundReview = $applicationRound->applicationRoundReviews->where('review_key', 'feedback')->first();
-                                    $applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
-                                @endphp
-                                @if(sizeof($applicationRound->followUps))
-                                    <div class="mt-3">
-                                        @foreach($applicationRound->followUps as $followUp)
-                                            <div class="d-flex align-items-center mb-1.5">
-                                                <i class="fa fa-clock-o fz-20 mr-1" aria-hidden="true"></i>
-                                                <span class="fz-14 leading-none">
-                                                    <span class="mr-0.5">Followed up by</span>
-                                                    <img src="{{ $followUp->conductedBy->avatar }}" class="w-20 h-20 rounded-circle mr-0.5" data-toggle="tooltip" title="{{ $followUp->conductedBy->name }}">
-                                                    <span class="mr-1.5">on {{ $followUp->created_at->format(config('constants.full_display_date_format')) }}</span>
-                                                    <a href="#" data-toggle="modal" data-target="#followUp{{$followUp->id}}">View feedback</a>
-                                                    @include('hr::follow-up.modal')
-                                                </span>
-                                            </div>
-                                        @endforeach
-                                    </div>
-                                @endif
-                                @if ($loop->last && $applicationRound->application->hasTag('need-follow-up'))
-                                    <div class="d-flex justify-content-start">
-                                        <button type="button" class="btn btn-sm btn-info fz-14 leading-none text-white rounded-0 py-1" data-toggle="modal" data-target="#followUpModal">Follow up</button>
-                                    </div>
-                                    @include('hr.application.follow-up-modal')
-                                @endif
-                                <div class="card mb-3">
-                                    <div class="card-header d-flex align-items-center justify-content-between">
-                                        <div class="d-flex flex-column">
-                                            <div>
-                                                {{ $applicationRound->round->name }}
-                                                <span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
-                                                    <i class="fa fa-info-circle fa-lg"></i>
-                                                </span>
-                                            </div>
-                                            @if ($applicationRound->round_status)
-                                                <span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
-                                            @endif
-                                        </div>
-                                        
-                                        <div class="d-flex align-items-center">
-                                            <div class="d-flex flex-column align-items-end">
-                                                @if ($applicationRound->noShow && $applicationRound->round->reminder_enabled)
-                                                    <span class="text-danger"><i class="fa fa-warning fa-lg"></i>&nbsp;{{ config('constants.hr.status.no-show-reminded.title') }}</span>
-                                                @endif
-                            
-                                                @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
-                                                    <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
-                                                @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
-                                                    <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
-                                                @endif
-                                                @if ($applicationRound->round_status && $applicationRound->conducted_date)
-                                                    <span>Conducted on: {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
-                                                @endif
-                                            </div>
-                                            
-                                            <div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse" data-target="#pre-trial-collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
-                                        </div>
-                                    </div>
-                                    <form action="/hr/recruitment/applications/rounds/{{ $applicationRound->id }}" method="POST" enctype="multipart/form-data" class="applicant-round-form">
-                                        {{ csrf_field() }}
-                                        {{ method_field('PATCH') }}
-                                        <div id="pre-trial-collapse_{{ $loop->iteration }}" class="collapse {{ $application->latestApplicationRound->round->isTrialRound()? '' : ($loop->last ? 'show' : '') }}">
-                                            @if($applicationRound->round->name == "Resume Screening")
-                                                <div class="card-body border-0">
-                                                    <div class="card-header border-0">
-                                                        <div class="d-flex justify-content-between">
-                                                            <div>Applicant Details</div>
-                                                            @foreach ($application->tags as $tag)
-                                                                <div class="badge text-uppercase fz-xl-12 c-pointer" style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color  }};" data-toggle="tooltip" data-placement="top" title="{{ $tag->description }}">
-                                                                    @if ($tag->icon)
-                                                                        {!! config("tags.icons.{$tag->icon}") !!}
-                                                                    @endif
-                                                                    {{ $tag->name }}
-                                                                </div>
-                                                            @endforeach
-                                                            @if (!in_array($application->status, ['in-progress', 'new']))
-                                                                <div class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
-                                                                    {{ config("constants.hr.status.$application->status.title") }}
-                                                                </div>
-                                                            @endif
-                                                        </div>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-row">
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Name</label>
-                                                                <div>
-                                                                    {{ $applicant->name }}
-                                                                    @if ($applicant->linkedin)
-                                                                        <a href="{{ $applicant->linkedin }}" target="_blank"><i class="fa fa-linkedin-square pl-1 fa-lg"></i></a>
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Applied for</label>
-                                                                <div>
-                                                                    <a href="{{ $application->job->link }}" target="_blank">
-                                                                        <span>{{ $application->job->title }}</span>
-                                                                        <i class="fa fa-external-link fz-14" aria-hidden="true"></i>
-                                                                    </a>
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Phone</label>
-                                                                <div>{{ $applicant->phone ?? '-' }}</div>
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Email</label>
-                                                                <div>{{ $applicant->email }}</div>
-                                                            </div>
-                                                            
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">College</label>
-                                                                @if(!$applicant->hr_university_id)
-                                                                    <div id="applicant_college">{{ $applicant->college ?? '-' }}</div>
-                                                                @else
-                                                                    <div id="applicant_college">{{ $applicant->university->name ?? '-' }}</div>
-                                                                @endif
-                                                                @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                <div class="mt-2 evaluation-score">
-                                                                    <input type="radio" class="toggle-button" name="college" id="college_evaluation_1">
-                                                                    <label for="college_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                    <input type="radio" class="toggle-button" name="college" id="college_evaluation_2">
-                                                                    <label for="college_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                </div>
-                                                                @endif
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Course</label>
-                                                                <div>{{ $applicant->course ?? '-' }}</div>
-                                                                @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                <div class="mt-2 evaluation-score">
-                                                                    <input type="radio" class="toggle-button" name="course" id="course_evaluation_1">
-                                                                    <label for="course_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                    <input type="radio" class="toggle-button" name="course" id="course_evaluation_2">
-                                                                    <label for="course_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                </div>
-                                                                @endif
-                                                            </div>
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Resume</label>
-                                                                <div>
-                                                                    @if ($application->resume)
-                                                                        @include('hr.application.inline-resume', ['resume' => $application->resume])
-                                                                    @else
-                                                                        –
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Graduation Year</label>
-                                                                <div>
-                                                                    {{ $applicant->graduation_year ?? '-' }}&nbsp;
-                                                                    @includeWhen(isset($hasGraduated) && !$hasGraduated, 'hr.job-to-internship-modal', ['application' => $application])
-                                                                    @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                    <div class="mt-2 evaluation-score">
-                                                                        <input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_1">
-                                                                        <label for="graduation_year_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                        <input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_2">
-                                                                        <label for="graduation_year_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                    </div>
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                            @if (isset($applicant->reference))
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Reference</label>
-                                                                <div>{{ $applicant->reference ?? '-' }}</div>
-                                                            </div>
-                                                            @endif
-                                                            @if (isset($applicationFormDetails->value))
-                                                                @foreach(json_decode($applicationFormDetails->value) as $field => $value)
-                                                                    <div class="form-group col-md-12">
-                                                                        <label class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
-                                                                        <div>{{ $value }}</div>
-                                                                        @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                        <div class="mt-2 evaluation-score">
-                                                                            <input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_1">
-                                                                            <label for="reason_for_eligibility_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                            <input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_2">
-                                                                            <label for="reason_for_eligibility_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                        </div>
-                                                                        @endif
-                                                                    </div>
-                                                                @endforeach
-                                                            @endif
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            @endif
-                                            <div class="card-body">
-                                                @if ( !$applicationRound->round_status)
-                                                    <div class="form-row">
-                                                        <div class="form-group col-md-5">
-                                                            <label for="scheduled_date" class="fz-14 leading-none text-secondary w-100p">
-                                                                <div>
-                                                                    <i class="fa fa-calendar" aria-hidden="true"></i>
-                                                                    <span>Scheduled date</span>
-                                                                    @if($applicationRound->scheduled_date)
-                                                                        @if($applicationRound->hangout_link)
-                                                                            <a target="_blank" class="ml-5 font-muli-bold" href="{{ $applicationRound->hangout_link }}">
-                                                                                <i class="fa fa-video-camera" aria-hidden="true"></i>
-                                                                                <span>Meeting Link</span>
-                                                                            </a>
-                                                                        @endif
-                                                                    @endif
-                                                                </div>
-                                                            </label>
-                                                            @if ($applicationRound->scheduled_date)
-                                                                <input type="datetime-local" 
-                                                                    name="scheduled_date" id="scheduled_date" 
-                                                                    class="form-control form-control-sm" 
-                                                                    value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
-                                                            @else
-                                                                <div class="fz-16 leading-tight">Pending calendar confirmation</div>
-                                                            @endif
-                                                        </div>
-                                                        <div class="form-group col-md-4">
-                                                            <label for="scheduled_person_id" class="fz-14 leading-none text-secondary">
-                                                                <i class="fa fa-user" aria-hidden="true"></i>
-                                                                <span>Scheduled for</span>
-                                                            </label>
-                                                            @if ($applicationRound->scheduled_date)
-                                                                <select name="scheduled_person_id" id="scheduled_person_id" class="form-control form-control-sm" >
-                                                                    @foreach ($interviewers as $interviewer)
-                                                                        @php
-                                                                            $selected = $applicationRound->scheduled_person_id == $interviewer->id ? 'selected="selected"' : '';
-                                                                        @endphp
-                                                                        <option value="{{ $interviewer->id }}" {{ $selected }}>
-                                                                            {{ $interviewer->name }}
-                                                                        </option>
-                                                                    @endforeach
-                                                                </select>
-                                                            @else
-                                                                <div class="fz-16 leading-tight">
-                                                                    <img src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" class="w-25 h-25 rounded-circle">
-                                                                    <span>{{ $applicationRound->scheduledPerson->name }}</span>
-                                                                </div>
-                                                            @endif     
-                                                        </div>
-                                                        @if ($applicationRound->scheduled_date)
-                                                            <div class="form-group col-md-3 d-flex align-items-end">
-                                                                <button type="button" class="py-1 mb-0 btn btn-info btn-sm round-submit update-schedule" data-action="schedule-update">Update Schedule</button>
-                                                            </div>
-                                                        @endif
-                                                    </div>
-                                                @endif 
-                                                @if($applicationRound->round->name == "Resume Screening")                    
-                                                    <div class="form-row">
-                                                        <div class="form-group col-md-12">
-                                                            <button type="button" class="btn btn-theme-fog btn-sm" @click="getApplicationEvaluation({{ $applicationRound->id }})">Application Evaluation</button>
-                                                        </div>
-                                                    </div>
-                                                @endif
-                                                <div class="form-row">
-                                                    <div class="form-group col-md-12">
-                                                        @php
-                                                            if ($loop->last && sizeOf($errors)) {
-                                                                $applicationRoundReviewValue = old('reviews.feedback');
-                                                            }
-                                                        @endphp
-                                                        <textarea name="reviews[{{ $applicationRound->id }}][feedback]" id="reviews[{{ $applicationRound->id }}][feedback]" rows="6" class="form-control" placeholder="Enter comments...">{{ $applicationRoundReviewValue }}</textarea>
-                                                    </div>
-                                                </div>
-                                                <div class="form-row d-flex justify-content-end">
-                                                    <button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
-                                                </div>
-                                            </div>
-                                            @php
-                                                $showFooter = false;
-                                                if ($loop->last && !$application->latestApplicationRound->round->isTrialRound()) {
-                                                    if (in_array($applicationRound->application->status, [config('constants.hr.status.sent-for-approval.label'), 
-                                                    config('constants.hr.status.approved.label')])) {
-                                                        $showFooter = true;
-                                                    }
-                                                    elseif (in_array($applicationRound->round_status, [null, config('constants.hr.status.rejected.label')])) {
-                                                        $showFooter = true;
-                                                    }
-                                                }
-                                                elseif (!$applicationRound->mail_sent) {
-                                                    $showFooter = true;
-                                                }
-                                            @endphp
-                                            @if ($showFooter)
-                                                <div class="card-footer">
-                                                    <div class="d-flex align-items-center">
-                                                        @if(!$application->latestApplicationRound->round->isTrialRound())
-                                                            @if ($applicationRound->showActions)
-                                                                <select name="action_type" id="action_type" 
-                                                                class="form-control w-50p" v-on:change="onSelectNextRound($event)" 
-                                                                data-application-job-rounds="{{ json_encode($application->job->exceptTrialRounds) }}">
-                                                                    <option v-for="round in applicationJobRounds" value="round" 
-                                                                    :data-next-round-id="round.id">Move to @{{ round.name }}</option>
-                                                                    <option value="send-for-approval">Send for approval</option>
-                                                                    <option value="approve">Approve</option>
-                                                                    <option value="onboard">Onboard</option>
-                                                                </select>
-                                                                <button type="button" class="btn btn-success ml-2" @click="takeAction()">Take action</button>
-                                                            @endif
-                                                            @if ($loop->last && !$application->isRejected())
-                                                                {{-- @if ($applicantOpenApplications->count() > 1) --}}
-                                                                    <button type="button" class="btn btn-outline-danger ml-2" id="rejectApplication" @click="rejectApplication()">Reject</button>
-                                                                    @include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
-                                                                {{-- @else --}}
-                                                                    {{-- <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject" data-toggle="modal" data-target="#application_reject_modal">Reject</button> --}}
-                                                                {{-- @endif --}}
-                                                            @endif
-                                                        @endif
-                                                        @if (!is_null($applicationRound->round_status) && !$applicationRound->mail_sent)
-                                                            <button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
-                                                        @endif
-                                                    </div>
-                                                </div>
-                                            @endif
-                                        </div>
-                                        <input type="hidden" name="action" value="updated">
-                                        <input type="hidden" name="next_round" value="">
-                                        @if ($loop->last && !$application->latestApplicationRound->round->isTrialRound())
-                                            <input type="hidden" name="current_applicationround_id" id="current_applicationround_id" value="{{ $applicationRound->id }}">
-                                        @endif
-                                        @includeWhen($applicationRound->showActions, 'hr.round-review-confirm-modal', 
-                                        ['applicationRound' => $applicationRound])
-                                        @if(!$application->latestApplicationRound->round->isTrialRound())
-                                            @includeWhen($loop->last, 'hr.application.send-for-approval-modal')
-                                            @includeWhen($loop->last, 'hr.application.onboard-applicant-modal')
-                                            @includeWhen($loop->last, 'hr.application.approve-applicant-modal') 
-                                        @endif               
-                                    </form>                
-                                </div>
-                                @include('hr.round-guide-modal', ['round' => $applicationRound->round])
-                                @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
-                                @include('hr.application.application-evaluation', ['round' => $applicationRound->round])
-                            @endforeach
-                        </div>
-                    </div>
-                @else
-                    @foreach ($application->applicationRoundsExceptTrial as $applicationRound)
-                        @php
-                            $applicationRoundReview = $applicationRound->applicationRoundReviews->where('review_key', 'feedback')->first();
-                            $applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
-                        @endphp
-                        <br>
-                        @if(sizeof($applicationRound->followUps))
-                            <div class="mt-3">
-                                @foreach($applicationRound->followUps as $followUp)
-                                    <div class="d-flex align-items-center mb-1.5">
-                                        <i class="fa fa-clock-o fz-20 mr-1" aria-hidden="true"></i>
-                                        <span class="fz-14 leading-none">
-                                            <span class="mr-0.5">Followed up by</span>
-                                            <img src="{{ $followUp->conductedBy->avatar }}" class="w-20 h-20 rounded-circle mr-0.5" data-toggle="tooltip" title="{{ $followUp->conductedBy->name }}">
-                                            <span class="mr-1.5">on {{ $followUp->created_at->format(config('constants.full_display_date_format')) }}</span>
-                                            <a href="#" data-toggle="modal" data-target="#followUp{{$followUp->id}}">View feedback</a>
-                                            @include('hr::follow-up.modal')
-                                        </span>
-                                    </div>
-                                @endforeach
-                            </div>
-                        @endif
-                        @if ($loop->last && $applicationRound->application->hasTag('need-follow-up'))
-                            <div class="d-flex justify-content-start">
-                                <button type="button" class="btn btn-sm btn-info fz-14 leading-none text-white rounded-0 py-1" data-toggle="modal" data-target="#followUpModal">Follow up</button>
-                            </div>
-                            @include('hr.application.follow-up-modal')
-                        @endif
-                        <div class="card">
-                            <div class="card-header d-flex align-items-center justify-content-between">
-                                <div class="d-flex flex-column">
-                                    <div>
-                                        {{ $applicationRound->round->name }}
-                                        <span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
-                                            <i class="fa fa-info-circle fa-lg"></i>
-                                            <span class="ml-2">Assigned to<img class="ml-2 w-25 h-25 rounded-circle" src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" data-toggle="tooltip" data-placement="top" title="{{ $applicationRound->scheduledPerson->name }}"></span>
-                                        </span>
-                                    </div>
-                                    @if ($applicationRound->round_status && $applicationRound->conductedPerson)
-                                        <span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
-                                    @endif
-                                </div>
-                                <div class="d-flex align-items-center">
-                                    <div class="d-flex flex-column align-items-end">
-                                        @if ($applicationRound->noShow && $applicationRound->round->reminder_enabled)
-                                            <span class="text-danger"><i class="fa fa-warning fa-lg"></i>&nbsp;{{ config('constants.hr.status.no-show-reminded.title') }}</span>
-                                        @endif
-                                        @if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
-                                            <div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
-                                        @elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
-                                            <div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
-                                        @endif
-                                        @if ($applicationRound->round_status && $applicationRound->conducted_date)
-                                            <span>Conducted on: {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
-                                        @endif
-                                    </div>
-                                    <div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
-                                </div>
-                            </div>
-                            @if($application->latestApplicationRound->round->name != 'Trial Program')
-                                <form action="/hr/recruitment/applications/rounds/{{ $applicationRound->id }}" method="POST" enctype="multipart/form-data" class="applicant-round-form">
-                        
-                                    {{ csrf_field() }}
-                                    {{ method_field('PATCH') }}
-                                    <div id="collapse_{{ $loop->iteration }}" class="collapse {{ $loop->last ? 'show' : '' }}">
-                                        <div class="card-body">
-                                            @if($applicationRound->round->name == "Resume Screening")
-                                                <div class="card mb-2 border-0">
-                                                    <div class="card-header border-0">
-                                                        <div class="d-flex justify-content-between">
-                                                            <div>Applicant Details</div>
-                                                            @foreach ($application->tags as $tag)
-                                                                <div class="badge text-uppercase fz-xl-12 c-pointer" style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color  }};" data-toggle="tooltip" data-placement="top" title="{{ $tag->description }}">
-                                                                    @if ($tag->icon)
-                                                                        {!! config("tags.icons.{$tag->icon}") !!}
-                                                                    @endif
-                                                                    {{ $tag->name }}
-                                                                </div>
-                                                            @endforeach
-                                                            @if (!in_array($application->status, ['in-progress', 'new']))
-                                                                <div class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
-                                                                    {{ config("constants.hr.status.$application->status.title") }}
-                                                                </div>
-                                                            @endif
-                                                        </div>
-                                                    </div>
-                                                    <div class="card-body">
-                                                        <div class="form-row">
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Name</label>
-                                                                <div>
-                                                                    {{ $applicant->name }}
-                                                                    @if ($applicant->linkedin)
-                                                                        <a href="{{ $applicant->linkedin }}" target="_blank"><i class="fa fa-linkedin-square pl-1 fa-lg"></i></a>
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Applied for</label>
-                                                                <div>
-                                                                    <a href="{{ $application->job->link }}" target="_blank">
-                                                                        <span>{{ $application->job->title }}</span>
-                                                                        <i class="fa fa-external-link fz-14" aria-hidden="true"></i>
-                                                                    </a>
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Phone</label>
-                                                                <div>{{ $applicant->phone ?? '-' }}</div>
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Email</label>
-                                                                <div>{{ $applicant->email }}</div>
-                                                            </div>
-                                                            
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">College</label>
-                                                                @if(!$applicant->hr_university_id)
-                                                                    <div id="applicant_college">{{ $applicant->college ?? '-' }}</div>
-                                                                @else
-                                                                    <div id="applicant_college">{{ $applicant->university->name ?? '-' }}</div>
-                                                                @endif
-                                                                @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                <div class="mt-2 evaluation-score">
-                                                                    <input type="radio" class="toggle-button" name="college" id="college_evaluation_1">
-                                                                    <label for="college_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                    <input type="radio" class="toggle-button" name="college" id="college_evaluation_2">
-                                                                    <label for="college_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                </div>
-                                                                @endif
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Course</label>
-                                                                <div>{{ $applicant->course ?? '-' }}</div>
-                                                                @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                <div class="mt-2 evaluation-score">
-                                                                    <input type="radio" class="toggle-button" name="course" id="course_evaluation_1">
-                                                                    <label for="course_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                    <input type="radio" class="toggle-button" name="course" id="course_evaluation_2">
-                                                                    <label for="course_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                </div>
-                                                                @endif
-                                                            </div>
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Resume</label>
-                                                                <div>
-                                                                    @if ($application->resume)
-                                                                        @include('hr.application.inline-resume', ['resume' => $application->resume])
-                                                                    @else
-                                                                        –
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                            <div class="form-group offset-md-1 col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Graduation Year</label>
-                                                                <div>
-                                                                    {{ $applicant->graduation_year ?? '-' }}&nbsp;
-                                                                    @if(isset($hasGraduated) && !$hasGraduated)
-                                                                        <span class="badge badge-danger c-pointer" data-toggle="modal" data-target="#job_to_internship">Move to internship</span>
-                                                                    @endif
-                                                                    @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                    <div class="mt-2 evaluation-score">
-                                                                        <input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_1">
-                                                                        <label for="graduation_year_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                        <input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_2">
-                                                                        <label for="graduation_year_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                    </div>
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                            @if (isset($applicant->reference))
-                                                            <div class="form-group col-md-5">
-                                                                <label class="text-secondary fz-14 leading-none mb-0.16">Reference</label>
-                                                                <div>{{ $applicant->reference ?? '-' }}</div>
-                                                            </div>
-                                                            @endif
-                                                            @if (isset($applicationFormDetails->value))
-                                                                @foreach(json_decode($applicationFormDetails->value) as $field => $value)
-                                                                    <div class="form-group col-md-12">
-                                                                        <label class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
-                                                                        <div>{{ $value }}</div>
-                                                                        @if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
-                                                                        <div class="mt-2 evaluation-score">
-                                                                            <input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_1">
-                                                                            <label for="reason_for_eligibility_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
-                                                                            <input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_2">
-                                                                            <label for="reason_for_eligibility_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
-                                                                        </div>
-                                                                        @endif
-                                                                    </div>
-                                                                @endforeach
-                                                            @endif
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            @endif
-                                            @if ( !$applicationRound->round_status)
-                                                <div class="form-row">
-                                                    <div class="form-group col-md-5">
-                                                        <label for="scheduled_date" class="fz-14 leading-none text-secondary w-100p">
-                                                            <div>
-                                                                <i class="fa fa-calendar" aria-hidden="true"></i>
-                                                                <span>Scheduled date</span>
-                                                                    @if($applicationRound->scheduled_date)
-                                                                        @if($applicationRound->hangout_link)
-                                                                            <a target="_blank" class="ml-5 font-muli-bold" href="{{ $applicationRound->hangout_link }}">
-                                                                                <i class="fa fa-video-camera" aria-hidden="true"></i>
-                                                                                <span>Meeting Link</span>
-                                                                            </a>
-                                                                        @endif
-                                                                    @endif
-                                                            </div>
-                                                        </label>
-                                                        @if ($applicationRound->scheduled_date)
-                                                            <input type="datetime-local" 
-                                                                name="scheduled_date" id="scheduled_date" 
-                                                                class="form-control form-control-sm" 
-                                                                value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
-                                                        @else
-                                                            <div class="fz-16 leading-tight">Pending calendar confirmation</div>
-                                                        @endif
-                                                    </div>
-                                                    <div class="form-group col-md-4">
-                                                        <label for="scheduled_person_id" class="fz-14 leading-none text-secondary">
-                                                            <i class="fa fa-user" aria-hidden="true"></i>
-                                                            <span>Scheduled for</span>
-                                                        </label>
-                                                        @if ($applicationRound->scheduled_date)
-                                                            <select name="scheduled_person_id" id="scheduled_person_id" class="form-control form-control-sm" >
-                                                                @foreach ($interviewers as $interviewer)
-                                                                    @php
-                                                                        $selected = $applicationRound->scheduled_person_id == $interviewer->id ? 'selected="selected"' : '';
-                                                                    @endphp
-                                                                    <option value="{{ $interviewer->id }}" {{ $selected }}>
-                                                                        {{ $interviewer->name }}
-                                                                    </option>
-                                                                @endforeach
-                                                            </select>
-                                                        @else
-                                                            <div class="fz-16 leading-tight">
-                                                                <img src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" class="w-25 h-25 rounded-circle">
-                                                                <span>{{ $applicationRound->scheduledPerson->name }}</span>
-                                                            </div>
-                                                        @endif
-                                                        
-                                                    </div>
-                                                    @if ($applicationRound->scheduled_date)
-                                                        <div class="form-group col-md-3 d-flex align-items-end">
-                                                        <button type="button" class="py-1 mb-0 btn btn-info btn-sm round-submit update-schedule" data-action="schedule-update">Update Schedule</button>
-                                                    </div>
-                                                    @endif
-                                                </div>
-                                            @endif 
-                                            @if($applicationRound->round->name == "Resume Screening")   
-                                                <div class="form-row">
-                                                    <div class="form-group col-md-12">
-                                                        <button type="button" class="btn btn-theme-fog btn-sm" @click="getApplicationEvaluation({{ $applicationRound->id }})">Application Evaluation</button>
-                                                    </div>
-                                                    @if(session('status') || $application->marks  && $application->latestApplicationRound->hr_round_id == 1)
-                                                    <div class="form-row">
-                                                        <div class="form-group my-2 pl-2">
-                                                            <h4>
-                                                                <span>Result: </span>
-                                                                @if($application->marks !== null)
-                                                                    @if($application->marks >= config('hr.applicationEvaluation.cutoffScore'))
-                                                                        <span class="text-success">Passing</span>
-                                                                    @else
-                                                                        <span class="text-danger">Failing</span>
-                                                                    @endif
-                                                                @endif
-                                                            </h4>
-                                                        </div>
-                                                    </div>
-                                                    @endif
-                                                </div>
-                                            @endif
-                                            <div class="form-row">
-                                                <div class="form-group col-md-12">
-                                                    @php
-                                                        if ($loop->last && sizeOf($errors)) {
-                                                            $applicationRoundReviewValue = old('reviews.feedback');
-                                                        }
-                                                    @endphp
-                                                    <textarea name="reviews[{{ $applicationRound->id }}][feedback]" id="reviews[{{ $applicationRound->id }}][feedback]" rows="6" class="form-control" placeholder="Enter comments...">{{ $applicationRoundReviewValue }}</textarea>
-                                                </div>
-                                            </div>
-                                            <div class="form-row d-flex justify-content-end">
-                                                <button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
-                                            </div>
-                                        </div>
-                                        @php
-                                            $showFooter = false;
-                                            if ($loop->last) {
-                                                if (in_array($applicationRound->application->status, [config('constants.hr.status.sent-for-approval.label'), 
-                                                config('constants.hr.status.approved.label')])) {
-                                                    $showFooter = true;
-                                                }
-                                                elseif (in_array($applicationRound->round_status, [null, config('constants.hr.status.rejected.label')])) {
-                                                    $showFooter = true;
-                                                }
-                                            }
-                                            elseif (!$applicationRound->mail_sent) {
-                                                $showFooter = true;
-                                            }
-                                        @endphp
-                                        @if ($showFooter)
-                                        <div class="card-footer">
-                                            <div class="d-flex align-items-center">
-                                            @if ($applicationRound->showActions)
-                                                <select name="action_type" id="action_type" 
-                                                class="form-control w-50p" v-on:change="onSelectNextRound($event)" 
-                                                data-application-job-rounds="{{ json_encode($application->job->exceptTrialRounds) }}">
-                                                    <option v-for="round in applicationJobRounds" value="round" 
-                                                    :data-next-round-id="round.id">Move to @{{ round.name }}</option>
-                                                    <option value="send-for-approval">Send for approval</option>
-                                                    <option value="approve">Approve</option>
-                                                    <option value="onboard">Onboard</option>
-                                                </select>
-                                                <button type="button" class="btn btn-success ml-2" @click="takeAction()">Take action</button>
-                                            @endif
-                                            @if ($loop->last && !$application->isRejected())
-                                                {{-- @if ($applicantOpenApplications->count() > 1) --}}
-                                                    <button type="button" class="btn btn-outline-danger ml-2" id="rejectApplication" @click="rejectApplication()">Reject</button>
-                                                    @include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
-                                                {{-- @else --}}
-                                                    {{-- <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject" data-toggle="modal" data-target="#application_reject_modal">Reject</button> --}}
-                                                {{-- @endif --}}
-                                            @endif
-                                            @if (!is_null($applicationRound->round_status) && !$applicationRound->mail_sent)
-                                                <button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
-                                            @endif
-                                            </div>
-                                        </div>
-                                        @endif
-                                    </div>
-                                    <input type="hidden" name="action" value="updated">
-                                    
-                                    @if ($loop->last)
-                                        <input type="hidden" name="current_applicationround_id" id="current_applicationround_id" value="{{ $applicationRound->id }}">
-                                    @endif
-                                    @includeWhen($applicationRound->showActions, 'hr.round-review-confirm-modal', 
-                                    ['applicationRound' => $applicationRound])
-                                    @includeWhen($loop->last, 'hr.application.send-for-approval-modal')
-                                    @includeWhen($loop->last, 'hr.application.onboard-applicant-modal')
-                                    @includeWhen($loop->last, 'hr.application.approve-applicant-modal')
-                                </form>
-                            @endif
-                        </div>
-                        @include('hr.round-guide-modal', ['round' => $applicationRound->round])
-                        @includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
-                        @includeWhen(isset($hasGraduated) && !$hasGraduated, 'hr.job-to-internship-modal', ['application' => $application])
-                        @include('hr.application.application-evaluation', ['round' => $applicationRound->round])
-                    @endforeach
-                @endif
-            </div>  
-        </div>
-    </div>
+	<div class="row">
+		<div class="col-md-12">
+			<br>
+			@includeWhen($type == 'volunteer', 'hr.volunteers.menu')
+			@includeWhen($type == 'recruitment', 'hr.menu')
+			<br><br>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-3">
+			@include('hr.application.timeline', ['timeline' => $timeline, 'currentApplication' => $application])
+		</div>
+		<div v-bind:class="[showResumeFrame ? 'offset-md-2 col-md-7 pl-9' : 'col-md-8']">
+			<div class="card bg-transparent border-0">
+				@if(sizeOf($application->trialApplicationRounds))
+					<nav>
+						<div class="nav nav-pills" id="nav-tab" role="tablist">
+							<a class="nav-item nav-link {{ $application->latestApplicationRound->round->isTrialRound() ? 'active' : '' }}" id="nav-trial-tab" data-toggle="tab" href="#nav-trial" role="tab" aria-controls="nav-trial" aria-selected="true">Trial</a>
+							<a class="nav-item nav-link {{ $application->latestApplicationRound->round->isTrialRound() ? '' : 'active' }}" id="nav-pre-trial-tab" data-toggle="tab" href="#nav-pre-trial" role="tab" aria-controls="nav-pre-trial" aria-selected="false">Pre-Trial</a>
+						</div>
+					</nav>
+					<div class="tab-content" id="nav-tabContent">
+						<div class="tab-pane fade {{ $application->latestApplicationRound->round->isTrialRound() ? 'show active' : '' }}" id="nav-trial" role="tabpanel" aria-labelledby="nav-trial-tab">               
+							<br>
+							@foreach ($application->trialApplicationRounds as $applicationRound)
+								@php
+									$applicationRoundReview = $applicationRound->applicationRoundReviews->where('review_key', 'feedback')->first();
+									$applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
+								@endphp
+								@if(sizeof($applicationRound->followUps))
+									<div class="my-2">
+									@foreach($applicationRound->followUps as $followUp)
+										<div class="d-flex align-items-center mb-1.5">
+											<i class="fa fa-clock-o fz-20 mr-1" aria-hidden="true"></i>
+											<span class="fz-14 leading-none">
+												<span class="mr-0.5">Followed up by</span>
+												<img src="{{ $followUp->conductedBy->avatar }}" class="w-20 h-20 rounded-circle mr-0.5" data-toggle="tooltip" title="{{ $followUp->conductedBy->name }}">
+												<span class="mr-1.5">on {{ $followUp->created_at->format(config('constants.full_display_date_format')) }}</span>
+												<a href="#" data-toggle="modal" data-target="#followUp{{$followUp->id}}">View feedback</a>
+												@include('hr::follow-up.modal')
+											</span>
+										</div>
+									@endforeach
+									</div>
+								@endif
+								@if ($loop->last && $applicationRound->application->hasTag('need-follow-up'))
+									<div class="d-flex justify-content-start">
+										<button type="button" class="btn btn-sm btn-info fz-14 leading-none text-white rounded-0 py-1" data-toggle="modal" data-target="#followUpModal">Follow up</button>
+									</div>
+									@include('hr.application.follow-up-modal')
+								@endif
+								<div class="card mb-3">
+									<div class="card-header d-flex align-items-center justify-content-between">
+										<div class="d-flex flex-column">
+											<div>
+												{{$applicationRound->trialRound->name }}
+												<span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
+													<i class="fa fa-info-circle fa-lg"></i>
+												</span>
+											</div>
+											@if ($applicationRound->round_status)
+												<span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
+											@endif
+										</div>
+										<div class="d-flex align-items-center">
+											<div class="d-flex flex-column align-items-end">
+												@if ($applicationRound->noShow && $applicationRound->round->reminder_enabled)
+													<span class="text-danger"><i class="fa fa-warning fa-lg"></i>&nbsp;{{ config('constants.hr.status.no-show-reminded.title') }}</span>
+												@endif
+							
+												@if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
+													<div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
+												@elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
+													<div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
+												@endif
+												@if ($applicationRound->round_status && $applicationRound->conducted_date)
+													<span>Conducted on: {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
+												@endif
+											</div>
+											<div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
+										</div>
+									</div>
+									<form action="/
+									hr/recruitment/applications/rounds/{{ $applicationRound->id }}" method="POST" enctype="multipart/form-data" class="applicant-round-form">
+										{{ csrf_field() }}
+										{{ method_field('PATCH') }}
+										<div id="collapse_{{ $loop->iteration }}" class="collapse {{ $application->latestApplicationRound->round->isTrialRound()? ($loop->last ? 'show' : '') : '' }}">
+											<div class="card-body">
+												@if ( !$applicationRound->round_status)
+													<div class="form-row">
+														<div class="form-group col-md-5">
+															<label for="scheduled_date" class="fz-14 leading-none text-secondary w-100p">
+																<div>
+																<i class="fa fa-calendar" aria-hidden="true"></i>
+																<span>Scheduled date</span>
+																	@if($applicationRound->scheduled_date)
+																		@if($applicationRound->hangout_link)
+																			<a target="_blank" class="ml-5 font-muli-bold" href="{{ $applicationRound->hangout_link }}">
+																				<i class="fa fa-video-camera" aria-hidden="true"></i>
+																				<span>Meeting Link</span>
+																			</a>
+																		@endif
+																	@endif
+																</div>
+															</label>
+															@if ($applicationRound->scheduled_date)
+																<input type="datetime-local" 
+																	name="scheduled_date" id="scheduled_date" 
+																	class="form-control form-control-sm" 
+																	value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
+															@else
+																<div class="fz-16 leading-tight">Pending calendar confirmation</div>
+															@endif
+														</div>
+														<div class="form-group col-md-4">
+															<label for="scheduled_person_id" class="fz-14 leading-none text-secondary">
+																<i class="fa fa-user" aria-hidden="true"></i>
+																<span>Scheduled for</span>
+															</label>
+															@if ($applicationRound->scheduled_date)
+																<select name="scheduled_person_id" id="scheduled_person_id" class="form-control form-control-sm" >
+																	@foreach ($interviewers as $interviewer)
+																		@php
+																			$selected = $applicationRound->scheduled_person_id == $interviewer->id ? 'selected="selected"' : '';
+																		@endphp
+																		<option value="{{ $interviewer->id }}" {{ $selected }}>
+																			{{ $interviewer->name }}
+																		</option>
+																	@endforeach
+																</select>
+															@else
+																<div class="fz-16 leading-tight">
+																	<img src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" class="w-25 h-25 rounded-circle">
+																	<span>{{ $applicationRound->scheduledPerson->name }}</span>
+																</div>
+															@endif  
+														</div>
+														@if ($applicationRound->scheduled_date)
+															<div class="form-group col-md-3 d-flex align-items-end">
+																<button type="button" class="py-1 mb-0 btn btn-info btn-sm round-submit update-schedule" data-action="schedule-update">Update Schedule</button>
+															</div>
+														@endif
+													</div>
+												@endif
+												@if($applicationRound->round->name == "Resume Screening")
+													<div class="form-row">
+														<div class="form-group col-md-12">
+															<button type="button" class="btn btn-theme-fog btn-sm" @click="getApplicationEvaluation({{ $applicationRound->id }})">Application Evaluation</button>
+														</div>
+													</div>
+												@endif
+												<div class="form-row">
+													<div class="form-group col-md-12">
+														@php
+															if ($loop->last && sizeOf($errors)) {
+																$applicationRoundReviewValue = old('reviews.feedback');
+															}
+														@endphp
+														<textarea name="reviews[{{ $applicationRound->id }}][feedback]" id="reviews[{{ $applicationRound->id }}][feedback]" rows="6" class="form-control" placeholder="Enter comments...">{{ $applicationRoundReviewValue }}</textarea>
+													</div>
+												</div>
+												<div class="form-row d-flex justify-content-end">
+													<button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
+												</div>
+											</div>
+											@php
+												$showFooter = false;
+												if ($loop->last && $application->latestApplicationRound->round->isTrialRound()) {
+													if (in_array($applicationRound->application->status, [config('constants.hr.status.sent-for-approval.label'), 
+													config('constants.hr.status.approved.label')])) {
+														$showFooter = true;
+													}
+													elseif (in_array($applicationRound->round_status, [null, config('constants.hr.status.rejected.label')])) {
+														$showFooter = true;
+													}
+												}
+												elseif (!$applicationRound->mail_sent) {
+													$showFooter = true;
+												}
+											@endphp
+											@if ($showFooter)
+											<div class="card-footer">
+												<div class="d-flex align-items-center">
+													@if($application->latestApplicationRound->round->isTrialRound())
+														@if ($applicationRound->showActions)
+															<select name="action_type" id="action_type" 
+															class="form-control w-50p" v-on:change="onSelectNextRound($event)" 
+															data-application-job-rounds="{{ json_encode($application->job->trialRounds) }}">
+																<option v-for="round in applicationJobRounds" value="round" 
+																:data-next-round-id="round.id">Move to @{{ round.name }}</option>
+																<option value="send-for-approval">Send for approval</option>
+																<option value="approve">Approve</option>
+																<option value="onboard">Onboard</option>
+															</select>
+															<button type="button" class="btn btn-success ml-2" @click="takeAction()">Take action</button>
+														@endif
+														@if ($loop->last && !$application->isRejected())
+															{{-- @if ($applicantOpenApplications->count() > 1) --}}
+																<button type="button" class="btn btn-outline-danger ml-2" id="rejectApplication" @click="rejectApplication()">Reject</button>
+																@include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
+															{{-- @else --}}
+																{{-- <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject" data-toggle="modal" data-target="#application_reject_modal">Reject</button> --}}
+															{{-- @endif --}}
+														@endif
+													@endif
+													@if (!is_null($applicationRound->round_status) && !$applicationRound->mail_sent)
+														<button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
+													@endif
+												</div>
+											</div>
+											@endif
+										</div>
+										<input type="hidden" name="action" value="updated">
+										<input type="hidden" name="next_round" value="">
+										@if ($loop->last && $application->latestApplicationRound->round->isTrialRound())
+											<input type="hidden" name="current_applicationround_id" id="current_applicationround_id" value="{{ $applicationRound->id }}">
+										@endif
+										@includeWhen($applicationRound->showActions, 'hr.round-review-confirm-modal', 
+										['applicationRound' => $applicationRound])
+										@if($application->latestApplicationRound->round->isTrialRound())
+											@includeWhen($loop->last, 'hr.application.send-for-approval-modal')
+											@includeWhen($loop->last, 'hr.application.onboard-applicant-modal')
+											@includeWhen($loop->last, 'hr.application.approve-applicant-modal')
+										@endif
+									</form>                          
+								</div>
+								@include('hr.round-guide-modal', ['round' => $applicationRound->round])
+								@includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
+								@include('hr.application.application-evaluation', ['round' => $applicationRound->trialRound])
+							@endforeach
+						</div>
+						<div class="tab-pane fade {{ $application->latestApplicationRound->round->isTrialRound() ? '' : 'show active' }}" id="nav-pre-trial" role="tabpanel" aria-labelledby="nav-pre-trial-tab">
+							<br>
+							@foreach ($application->applicationRoundsExceptTrial as $applicationRound)
+								@php
+									$applicationRoundReview = $applicationRound->applicationRoundReviews->where('review_key', 'feedback')->first();
+									$applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
+								@endphp
+								@if(sizeof($applicationRound->followUps))
+									<div class="mt-3">
+										@foreach($applicationRound->followUps as $followUp)
+											<div class="d-flex align-items-center mb-1.5">
+												<i class="fa fa-clock-o fz-20 mr-1" aria-hidden="true"></i>
+												<span class="fz-14 leading-none">
+													<span class="mr-0.5">Followed up by</span>
+													<img src="{{ $followUp->conductedBy->avatar }}" class="w-20 h-20 rounded-circle mr-0.5" data-toggle="tooltip" title="{{ $followUp->conductedBy->name }}">
+													<span class="mr-1.5">on {{ $followUp->created_at->format(config('constants.full_display_date_format')) }}</span>
+													<a href="#" data-toggle="modal" data-target="#followUp{{$followUp->id}}">View feedback</a>
+													@include('hr::follow-up.modal')
+												</span>
+											</div>
+										@endforeach
+									</div>
+								@endif
+								@if ($loop->last && $applicationRound->application->hasTag('need-follow-up'))
+									<div class="d-flex justify-content-start">
+										<button type="button" class="btn btn-sm btn-info fz-14 leading-none text-white rounded-0 py-1" data-toggle="modal" data-target="#followUpModal">Follow up</button>
+									</div>
+									@include('hr.application.follow-up-modal')
+								@endif
+								<div class="card mb-3">
+									<div class="card-header d-flex align-items-center justify-content-between">
+										<div class="d-flex flex-column">
+											<div>
+												{{ $applicationRound->round->name }}
+												<span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
+													<i class="fa fa-info-circle fa-lg"></i>
+												</span>
+											</div>
+											@if ($applicationRound->round_status)
+												<span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
+											@endif
+										</div>
+										
+										<div class="d-flex align-items-center">
+											<div class="d-flex flex-column align-items-end">
+												@if ($applicationRound->noShow && $applicationRound->round->reminder_enabled)
+													<span class="text-danger"><i class="fa fa-warning fa-lg"></i>&nbsp;{{ config('constants.hr.status.no-show-reminded.title') }}</span>
+												@endif
+							
+												@if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
+													<div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
+												@elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
+													<div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
+												@endif
+												@if ($applicationRound->round_status && $applicationRound->conducted_date)
+													<span>Conducted on: {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
+												@endif
+											</div>
+											
+											<div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse" data-target="#pre-trial-collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
+										</div>
+									</div>
+									<form action="/hr/recruitment/applications/rounds/{{ $applicationRound->id }}" method="POST" enctype="multipart/form-data" class="applicant-round-form">
+										{{ csrf_field() }}
+										{{ method_field('PATCH') }}
+										<div id="pre-trial-collapse_{{ $loop->iteration }}" class="collapse {{ $application->latestApplicationRound->round->isTrialRound()? '' : ($loop->last ? 'show' : '') }}">
+											@if($applicationRound->round->name == "Resume Screening")
+												<div class="card-body border-0">
+													<div class="card-header border-0">
+														<div class="d-flex justify-content-between">
+															<div>Applicant Details</div>
+															@foreach ($application->tags as $tag)
+																<div class="badge text-uppercase fz-xl-12 c-pointer" style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color  }};" data-toggle="tooltip" data-placement="top" title="{{ $tag->description }}">
+																	@if ($tag->icon)
+																		{!! config("tags.icons.{$tag->icon}") !!}
+																	@endif
+																	{{ $tag->name }}
+																</div>
+															@endforeach
+															@if (!in_array($application->status, ['in-progress', 'new']))
+																<div class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
+																	{{ config("constants.hr.status.$application->status.title") }}
+																</div>
+															@endif
+														</div>
+													</div>
+													<div class="card-body">
+														<div class="form-row">
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Name</label>
+																<div>
+																	{{ $applicant->name }}
+																	@if ($applicant->linkedin)
+																		<a href="{{ $applicant->linkedin }}" target="_blank"><i class="fa fa-linkedin-square pl-1 fa-lg"></i></a>
+																	@endif
+																</div>
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Applied for</label>
+																<div>
+																	<a href="{{ $application->job->link }}" target="_blank">
+																		<span>{{ $application->job->title }}</span>
+																		<i class="fa fa-external-link fz-14" aria-hidden="true"></i>
+																	</a>
+																</div>
+															</div>
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Phone</label>
+																<div>{{ $applicant->phone ?? '-' }}</div>
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Email</label>
+																<div>{{ $applicant->email }}</div>
+															</div>
+															
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">College</label>
+																@if(!$applicant->hr_university_id)
+																	<div id="applicant_college">{{ $applicant->college ?? '-' }}</div>
+																@else
+																	<div id="applicant_college">{{ $applicant->university->name ?? '-' }}</div>
+																@endif
+																@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																<div class="mt-2 evaluation-score">
+																	<input type="radio" class="toggle-button" name="college" id="college_evaluation_1">
+																	<label for="college_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																	<input type="radio" class="toggle-button" name="college" id="college_evaluation_2">
+																	<label for="college_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																</div>
+																@endif
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Course</label>
+																<div>{{ $applicant->course ?? '-' }}</div>
+																@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																<div class="mt-2 evaluation-score">
+																	<input type="radio" class="toggle-button" name="course" id="course_evaluation_1">
+																	<label for="course_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																	<input type="radio" class="toggle-button" name="course" id="course_evaluation_2">
+																	<label for="course_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																</div>
+																@endif
+															</div>
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Resume</label>
+																<div>
+																	@if ($application->resume)
+																		@include('hr.application.inline-resume', ['resume' => $application->resume])
+																	@else
+																		–
+																	@endif
+																</div>
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Graduation Year</label>
+																<div>
+																	{{ $applicant->graduation_year ?? '-' }}&nbsp;
+																	@includeWhen(isset($hasGraduated) && !$hasGraduated, 'hr.job-to-internship-modal', ['application' => $application])
+																	@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																	<div class="mt-2 evaluation-score">
+																		<input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_1">
+																		<label for="graduation_year_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																		<input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_2">
+																		<label for="graduation_year_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																	</div>
+																	@endif
+																</div>
+															</div>
+															@if (isset($applicant->reference))
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Reference</label>
+																<div>{{ $applicant->reference ?? '-' }}</div>
+															</div>
+															@endif
+															@if (isset($applicationFormDetails->value))
+																@foreach(json_decode($applicationFormDetails->value) as $field => $value)
+																	<div class="form-group col-md-12">
+																		<label class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
+																		<div>{{ $value }}</div>
+																		@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																		<div class="mt-2 evaluation-score">
+																			<input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_1">
+																			<label for="reason_for_eligibility_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																			<input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_2">
+																			<label for="reason_for_eligibility_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																		</div>
+																		@endif
+																	</div>
+																@endforeach
+															@endif
+														</div>
+													</div>
+												</div>
+											@endif
+											<div class="card-body">
+												@if ( !$applicationRound->round_status)
+													<div class="form-row">
+														<div class="form-group col-md-5">
+															<label for="scheduled_date" class="fz-14 leading-none text-secondary w-100p">
+																<div>
+																	<i class="fa fa-calendar" aria-hidden="true"></i>
+																	<span>Scheduled date</span>
+																	@if($applicationRound->scheduled_date)
+																		@if($applicationRound->hangout_link)
+																			<a target="_blank" class="ml-5 font-muli-bold" href="{{ $applicationRound->hangout_link }}">
+																				<i class="fa fa-video-camera" aria-hidden="true"></i>
+																				<span>Meeting Link</span>
+																			</a>
+																		@endif
+																	@endif
+																</div>
+															</label>
+															@if ($applicationRound->scheduled_date)
+																<input type="datetime-local" 
+																	name="scheduled_date" id="scheduled_date" 
+																	class="form-control form-control-sm" 
+																	value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
+															@else
+																<div class="fz-16 leading-tight">Pending calendar confirmation</div>
+															@endif
+														</div>
+														<div class="form-group col-md-4">
+															<label for="scheduled_person_id" class="fz-14 leading-none text-secondary">
+																<i class="fa fa-user" aria-hidden="true"></i>
+																<span>Scheduled for</span>
+															</label>
+															@if ($applicationRound->scheduled_date)
+																<select name="scheduled_person_id" id="scheduled_person_id" class="form-control form-control-sm" >
+																	@foreach ($interviewers as $interviewer)
+																		@php
+																			$selected = $applicationRound->scheduled_person_id == $interviewer->id ? 'selected="selected"' : '';
+																		@endphp
+																		<option value="{{ $interviewer->id }}" {{ $selected }}>
+																			{{ $interviewer->name }}
+																		</option>
+																	@endforeach
+																</select>
+															@else
+																<div class="fz-16 leading-tight">
+																	<img src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" class="w-25 h-25 rounded-circle">
+																	<span>{{ $applicationRound->scheduledPerson->name }}</span>
+																</div>
+															@endif     
+														</div>
+														@if ($applicationRound->scheduled_date)
+															<div class="form-group col-md-3 d-flex align-items-end">
+																<button type="button" class="py-1 mb-0 btn btn-info btn-sm round-submit update-schedule" data-action="schedule-update">Update Schedule</button>
+															</div>
+														@endif
+													</div>
+												@endif 
+												@if($applicationRound->round->name == "Resume Screening")                    
+													<div class="form-row">
+														<div class="form-group col-md-12">
+															<button type="button" class="btn btn-theme-fog btn-sm" @click="getApplicationEvaluation({{ $applicationRound->id }})">Application Evaluation</button>
+														</div>
+													</div>
+												@endif
+												<div class="form-row">
+													<div class="form-group col-md-12">
+														@php
+															if ($loop->last && sizeOf($errors)) {
+																$applicationRoundReviewValue = old('reviews.feedback');
+															}
+														@endphp
+														<textarea name="reviews[{{ $applicationRound->id }}][feedback]" id="reviews[{{ $applicationRound->id }}][feedback]" rows="6" class="form-control" placeholder="Enter comments...">{{ $applicationRoundReviewValue }}</textarea>
+													</div>
+												</div>
+												<div class="form-row d-flex justify-content-end">
+													<button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
+												</div>
+											</div>
+											@php
+												$showFooter = false;
+												if ($loop->last && !$application->latestApplicationRound->round->isTrialRound()) {
+													if (in_array($applicationRound->application->status, [config('constants.hr.status.sent-for-approval.label'), 
+													config('constants.hr.status.approved.label')])) {
+														$showFooter = true;
+													}
+													elseif (in_array($applicationRound->round_status, [null, config('constants.hr.status.rejected.label')])) {
+														$showFooter = true;
+													}
+												}
+												elseif (!$applicationRound->mail_sent) {
+													$showFooter = true;
+												}
+											@endphp
+											@if ($showFooter)
+												<div class="card-footer">
+													<div class="d-flex align-items-center">
+														@if(!$application->latestApplicationRound->round->isTrialRound())
+															@if ($applicationRound->showActions)
+																<select name="action_type" id="action_type" 
+																class="form-control w-50p" v-on:change="onSelectNextRound($event)" 
+																data-application-job-rounds="{{ json_encode($application->job->exceptTrialRounds) }}">
+																	<option v-for="round in applicationJobRounds" value="round" 
+																	:data-next-round-id="round.id">Move to @{{ round.name }}</option>
+																	<option value="send-for-approval">Send for approval</option>
+																	<option value="approve">Approve</option>
+																	<option value="onboard">Onboard</option>
+																</select>
+																<button type="button" class="btn btn-success ml-2" @click="takeAction()">Take action</button>
+															@endif
+															@if ($loop->last && !$application->isRejected())
+																{{-- @if ($applicantOpenApplications->count() > 1) --}}
+																	<button type="button" class="btn btn-outline-danger ml-2" id="rejectApplication" @click="rejectApplication()">Reject</button>
+																	@include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
+																{{-- @else --}}
+																	{{-- <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject" data-toggle="modal" data-target="#application_reject_modal">Reject</button> --}}
+																{{-- @endif --}}
+															@endif
+														@endif
+														@if (!is_null($applicationRound->round_status) && !$applicationRound->mail_sent)
+															<button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
+														@endif
+													</div>
+												</div>
+											@endif
+										</div>
+										<input type="hidden" name="action" value="updated">
+										<input type="hidden" name="next_round" value="">
+										@if ($loop->last && !$application->latestApplicationRound->round->isTrialRound())
+											<input type="hidden" name="current_applicationround_id" id="current_applicationround_id" value="{{ $applicationRound->id }}">
+										@endif
+										@includeWhen($applicationRound->showActions, 'hr.round-review-confirm-modal', 
+										['applicationRound' => $applicationRound])
+										@if(!$application->latestApplicationRound->round->isTrialRound())
+											@includeWhen($loop->last, 'hr.application.send-for-approval-modal')
+											@includeWhen($loop->last, 'hr.application.onboard-applicant-modal')
+											@includeWhen($loop->last, 'hr.application.approve-applicant-modal') 
+										@endif               
+									</form>                
+								</div>
+								@include('hr.round-guide-modal', ['round' => $applicationRound->round])
+								@includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
+								@include('hr.application.application-evaluation', ['round' => $applicationRound->round])
+							@endforeach
+						</div>
+					</div>
+				@else
+					@foreach ($application->applicationRoundsExceptTrial as $applicationRound)
+						@php
+							$applicationRoundReview = $applicationRound->applicationRoundReviews->where('review_key', 'feedback')->first();
+							$applicationRoundReviewValue = $applicationRoundReview ? $applicationRoundReview->review_value : '';
+						@endphp
+						<br>
+						@if(sizeof($applicationRound->followUps))
+							<div class="mt-3">
+							@foreach($applicationRound->followUps as $followUp)
+									<div class="d-flex align-items-center mb-1.5">
+										<i class="fa fa-clock-o fz-20 mr-1" aria-hidden="true"></i>
+										<span class="fz-14 leading-none">
+											<span class="mr-0.5">Followed up by</span>
+											<img src="{{ $followUp->conductedBy->avatar }}" class="w-20 h-20 rounded-circle mr-0.5" data-toggle="tooltip" title="{{ $followUp->conductedBy->name }}">
+											<span class="mr-1.5">on {{ $followUp->created_at->format(config('constants.full_display_date_format')) }}</span>
+											<a href="#" data-toggle="modal" data-target="#followUp{{$followUp->id}}">View feedback</a>
+											@include('hr::follow-up.modal')
+										</span>
+									</div>
+								@endforeach
+							</div>
+						@endif
+						@if ($loop->last && $applicationRound->application->hasTag('need-follow-up'))
+							<div class="d-flex justify-content-start">
+								<button type="button" class="btn btn-sm btn-info fz-14 leading-none text-white rounded-0 py-1" data-toggle="modal" data-target="#followUpModal">Follow up</button>
+							</div>
+							@include('hr.application.follow-up-modal')
+						@endif
+						<div class="card">
+							<div class="card-header d-flex align-items-center justify-content-between">
+								<div class="d-flex flex-column">
+									<div>
+										{{ $applicationRound->round->name }}
+										<span title="{{ $applicationRound->round->name }} guide" class="modal-toggler-text text-muted" data-toggle="modal" data-target="#round_guide_{{ $applicationRound->round->id }}">
+											<i class="fa fa-info-circle fa-lg"></i>
+											<span class="ml-2">Assigned to<img class="ml-2 w-25 h-25 rounded-circle" src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" data-toggle="tooltip" data-placement="top" title="{{ $applicationRound->scheduledPerson->name }}"></span>
+										</span>
+									</div>
+									@if ($applicationRound->round_status && $applicationRound->conductedPerson)
+										<span>Conducted By: {{ $applicationRound->conductedPerson->name }}</span>
+									@endif
+								</div>
+								<div class="d-flex align-items-center">
+									<div class="d-flex flex-column align-items-end">
+										@if ($applicationRound->noShow && $applicationRound->round->reminder_enabled)
+											<span class="text-danger"><i class="fa fa-warning fa-lg"></i>&nbsp;{{ config('constants.hr.status.no-show-reminded.title') }}</span>
+										@endif
+										@if ($applicationRound->round_status === config('constants.hr.status.confirmed.label'))
+											<div class="text-success"><i class="fa fa-check"></i>&nbsp;{{ config('constants.hr.status.confirmed.title') }}</div>
+										@elseif ($applicationRound->round_status == config('constants.hr.status.rejected.label'))
+											<div class="text-danger"><i class="fa fa-close"></i>&nbsp;{{ config('constants.hr.status.rejected.title') }}</div>
+										@endif
+										@if ($applicationRound->round_status && $applicationRound->conducted_date)
+											<span>Conducted on: {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
+										@endif
+									</div>
+									<div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i></div>
+								</div>
+							</div>
+							@if($application->latestApplicationRound->round->name != 'Trial Program')
+								<form action="/hr/recruitment/applications/rounds/{{ $applicationRound->id }}" method="POST" enctype="multipart/form-data" class="applicant-round-form">
+						
+									{{ csrf_field() }}
+									{{ method_field('PATCH') }}
+									<div id="collapse_{{ $loop->iteration }}" class="collapse {{ $loop->last ? 'show' : '' }}">
+										<div class="card-body">
+											@if($applicationRound->round->name == "Resume Screening")
+												<div class="card mb-2 border-0">
+													<div class="card-header border-0">
+														<div class="d-flex justify-content-between">
+															<div>Applicant Details</div>
+															@foreach ($application->tags as $tag)
+																<div class="badge text-uppercase fz-xl-12 c-pointer" style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color  }};" data-toggle="tooltip" data-placement="top" title="{{ $tag->description }}">
+																	@if ($tag->icon)
+																		{!! config("tags.icons.{$tag->icon}") !!}
+																	@endif
+																	{{ $tag->name }}
+																</div>
+															@endforeach
+															@if (!in_array($application->status, ['in-progress', 'new']))
+																<div class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
+																	{{ config("constants.hr.status.$application->status.title") }}
+																</div>
+															@endif
+														</div>
+													</div>
+													<div class="card-body">
+														<div class="form-row">
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Name</label>
+																<div>
+																	{{ $applicant->name }}
+																	@if ($applicant->linkedin)
+																		<a href="{{ $applicant->linkedin }}" target="_blank"><i class="fa fa-linkedin-square pl-1 fa-lg"></i></a>
+																	@endif
+																</div>
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Applied for</label>
+																<div>
+																	<a href="{{ $application->job->link }}" target="_blank">
+																		<span>{{ $application->job->title }}</span>
+																		<i class="fa fa-external-link fz-14" aria-hidden="true"></i>
+																	</a>
+																</div>
+															</div>
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Phone</label>
+																<div>{{ $applicant->phone ?? '-' }}</div>
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Email</label>
+																<div>{{ $applicant->email }}</div>
+															</div>
+															
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">College</label>
+																@if(!$applicant->hr_university_id)
+																	<div id="applicant_college">{{ $applicant->college ?? '-' }}</div>
+																@else
+																	<div id="applicant_college">{{ $applicant->university->name ?? '-' }}</div>
+																@endif
+																@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																<div class="mt-2 evaluation-score">
+																	<input type="radio" class="toggle-button" name="college" id="college_evaluation_1">
+																	<label for="college_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																	<input type="radio" class="toggle-button" name="college" id="college_evaluation_2">
+																	<label for="college_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																</div>
+																@endif
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Course</label>
+																<div>{{ $applicant->course ?? '-' }}</div>
+																@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																<div class="mt-2 evaluation-score">
+																	<input type="radio" class="toggle-button" name="course" id="course_evaluation_1">
+																	<label for="course_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																	<input type="radio" class="toggle-button" name="course" id="course_evaluation_2">
+																	<label for="course_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																</div>
+																@endif
+															</div>
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Resume</label>
+																<div>
+																	@if ($application->resume)
+																		@include('hr.application.inline-resume', ['resume' => $application->resume])
+																	@else
+																		–
+																	@endif
+																</div>
+															</div>
+															<div class="form-group offset-md-1 col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Graduation Year</label>
+																<div>
+																	{{ $applicant->graduation_year ?? '-' }}&nbsp;
+																	@includeWhen(isset($hasGraduated) && !$hasGraduated, 'hr.job-to-internship-modal', ['application' => $application])
+																	@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																	<div class="mt-2 evaluation-score">
+																		<input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_1">
+																		<label for="graduation_year_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																		<input type="radio" class="toggle-button" name="graduation_year" id="graduation_year_evaluation_2">
+																		<label for="graduation_year_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																	</div>
+																	@endif
+																</div>
+															</div>
+															@if (isset($applicant->reference))
+															<div class="form-group col-md-5">
+																<label class="text-secondary fz-14 leading-none mb-0.16">Reference</label>
+																<div>{{ $applicant->reference ?? '-' }}</div>
+															</div>
+															@endif
+															@if (isset($applicationFormDetails->value))
+																@foreach(json_decode($applicationFormDetails->value) as $field => $value)
+																	<div class="form-group col-md-12">
+																		<label class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
+																		<div>{{ $value }}</div>
+																		@if(!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
+																		<div class="mt-2 evaluation-score">
+																			<input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_1">
+																			<label for="reason_for_eligibility_evaluation_1" class="mr-2 c-pointer thumb"><i class="fa fa-thumbs-up text-theme-gray-light hover-text-success checked-text-success" aria-hidden="true"></i></label>
+																			<input type="radio" class="toggle-button" name="reason_for_eligibility" id="reason_for_eligibility_evaluation_2">
+																			<label for="reason_for_eligibility_evaluation_2" class="c-pointer thumb"><i class="fa fa-thumbs-down text-theme-gray-light hover-text-danger checked-text-danger" aria-hidden="true"></i></label>
+																		</div>
+																		@endif
+																	</div>
+																@endforeach
+															@endif
+														</div>
+													</div>
+												</div>
+											@endif
+											
+											@if ( !$applicationRound->round_status)
+												<div class="form-row">
+													<div class="form-group col-md-5">
+														<label for="scheduled_date" class="fz-14 leading-none text-secondary w-100p">
+															<div>
+															<i class="fa fa-calendar" aria-hidden="true"></i>
+															<span>Scheduled date</span>
+																@if($applicationRound->scheduled_date)
+																	@if($applicationRound->hangout_link)
+																		<a target="_blank" class="ml-5 font-muli-bold" href="{{ $applicationRound->hangout_link }}">
+																			<i class="fa fa-video-camera" aria-hidden="true"></i>
+																			<span>Meeting Link</span>
+																		</a>
+																	@endif
+																@endif
+															</div>
+														</label>
+														@if ($applicationRound->scheduled_date)
+															<input type="datetime-local" 
+																name="scheduled_date" id="scheduled_date" 
+																class="form-control form-control-sm" 
+																value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
+														@else
+															<div class="fz-16 leading-tight">Pending calendar confirmation</div>
+														@endif
+													</div>
+													<div class="form-group col-md-4">
+														<label for="scheduled_person_id" class="fz-14 leading-none text-secondary">
+															<i class="fa fa-user" aria-hidden="true"></i>
+															<span>Scheduled for</span>
+														</label>
+														@if ($applicationRound->scheduled_date)
+															<select name="scheduled_person_id" id="scheduled_person_id" class="form-control form-control-sm" >
+																@foreach ($interviewers as $interviewer)
+																	@php
+																		$selected = $applicationRound->scheduled_person_id == $interviewer->id ? 'selected="selected"' : '';
+																	@endphp
+																	<option value="{{ $interviewer->id }}" {{ $selected }}>
+																		{{ $interviewer->name }}
+																	</option>
+																@endforeach
+															</select>
+														@else
+															<div class="fz-16 leading-tight">
+																<img src="{{ $applicationRound->scheduledPerson->avatar }}" alt="{{ $applicationRound->scheduledPerson->name }}" class="w-25 h-25 rounded-circle">
+																<span>{{ $applicationRound->scheduledPerson->name }}</span>
+															</div>
+														@endif
+														
+													</div>
+													@if ($applicationRound->scheduled_date)
+														<div class="form-group col-md-3 d-flex align-items-end">
+														<button type="button" class="py-1 mb-0 btn btn-info btn-sm round-submit update-schedule" data-action="schedule-update">Update Schedule</button>
+													</div>
+													@endif
+												</div>
+											@endif 
+											@if($applicationRound->round->name == "Resume Screening")                    
+												<div class="form-row">
+													<div class="form-group col-md-12">
+														<button type="button" class="btn btn-theme-fog btn-sm" @click="getApplicationEvaluation({{ $applicationRound->id }})">Application Evaluation</button>
+													</div>
+													@if(session('status') || $application->marks  && $application->latestApplicationRound->hr_round_id == 1)
+													<div class="form-row">
+														<div class="form-group my-2 pl-2">
+															<h4>
+																<span>Result: </span>
+																@if($application->marks >= config('hr.applicationEvaluation.cutoffScore'))
+																	<span class="text-success">Passing</span>
+																@else
+																	<span class="text-danger">Failing</span>
+																@endif
+															</h4>
+														</div>
+													</div>
+													@endif
+												</div>
+											@endif
+											<div class="form-row">
+												<div class="form-group col-md-12">
+													@php
+														if ($loop->last && sizeOf($errors)) {
+															$applicationRoundReviewValue = old('reviews.feedback');
+														}
+													@endphp
+													<textarea name="reviews[{{ $applicationRound->id }}][feedback]" id="reviews[{{ $applicationRound->id }}][feedback]" rows="6" class="form-control" placeholder="Enter comments...">{{ $applicationRoundReviewValue }}</textarea>
+												</div>
+											</div>
+											<div class="form-row d-flex justify-content-end">
+												<button type="button" class="btn btn-info btn-sm round-submit" data-action="update">Update feedback</button>
+											</div>
+										</div>
+										@php
+											$showFooter = false;
+											if ($loop->last) {
+												if (in_array($applicationRound->application->status, [config('constants.hr.status.sent-for-approval.label'), 
+												config('constants.hr.status.approved.label')])) {
+													$showFooter = true;
+												}
+												elseif (in_array($applicationRound->round_status, [null, config('constants.hr.status.rejected.label')])) {
+													$showFooter = true;
+												}
+											}
+											elseif (!$applicationRound->mail_sent) {
+												$showFooter = true;
+											}
+										@endphp
+										@if ($showFooter)
+										<div class="card-footer">
+											<div class="d-flex align-items-center">
+											@if ($applicationRound->showActions)
+												<select name="action_type" id="action_type" 
+												class="form-control w-42p" v-on:change="onSelectNextRound($event)" 
+												data-application-job-rounds="{{ json_encode($application->job->exceptTrialRounds) }}">
+													<option v-for="round in applicationJobRounds" value="round" 
+													:data-next-round-id="round.id">Move to @{{ round.name }}</option>
+													<option value="send-for-approval">Send for approval</option>
+													<option value="approve">Approve</option>
+													<option value="onboard">Onboard</option>
+												</select>
+												<button type="button" class="btn btn-success ml-2" @click="takeAction()">Take action</button>
+											@endif
+											<!-- Button trigger modal -->
+											<button type="button" class="btn btn-primary p-0 px-1 py-1 ml-2" data-toggle="modal" data-target="#ModalCenter">
+											  Put on Hold 
+											</button>
+											
+											<!-- Modal -->
+											<div class="modal fade" id="ModalCenter" tabindex="-1" role="dialog" aria-labelledby="ModalCenterTitle" aria-hidden="true">
+											  <div class="modal-dialog" role="document">
+												<div class="modal-content">
+													<div class="modal-header">
+														<h5 class="modal-title" id="ModalLongTitle">NOTE</h5>
+														<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+														<span aria-hidden="true">&times;</span>
+														</button>
+													</div>
+													<div class="modal-body">
+														<p>Do you want to put your application on Hold?</p>
+													</div>
+													<div class="modal-footer">
+														<button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
+														<button type="submit" class="btn btn-success px-4 round-submit" data-action="on-hold">Yes</button>
+													</div>
+												</div>
+											  </div>
+											</div>
+											@if ($loop->last && !$application->isRejected())
+												{{-- @if ($applicantOpenApplications->count() > 1) --}}
+													<button type="button" class="btn btn-outline-danger ml-2" id="rejectApplication" @click="rejectApplication()">Reject</button>
+													@include('hr.application.rejection-modal', ['currentApplication' => $application, 'allApplications' => $applicantOpenApplications ])
+												{{-- @else --}}
+													{{-- <button type="button" class="btn btn-outline-danger ml-2 round-submit" data-action="reject" data-toggle="modal" data-target="#application_reject_modal">Reject</button> --}}
+												{{-- @endif --}}
+											@endif
+											@if (!is_null($applicationRound->round_status) && !$applicationRound->mail_sent)
+												<button type="button" class="btn btn-primary ml-auto" data-toggle="modal" data-target="#round_{{ $applicationRound->id }}">Send mail</button>
+											@endif
+											</div>
+										</div>
+										@endif
+									</div>
+									<input type="hidden" name="action" value="updated">
+									<input type="hidden" name="next_round" value="">
+									@if ($loop->last)
+										<input type="hidden" name="current_applicationround_id" id="current_applicationround_id" value="{{ $applicationRound->id }}">
+									@endif
+									@includeWhen($applicationRound->showActions, 'hr.round-review-confirm-modal', 
+									['applicationRound' => $applicationRound])
+									@includeWhen($loop->last, 'hr.application.send-for-approval-modal')
+									@includeWhen($loop->last, 'hr.application.onboard-applicant-modal')
+									@includeWhen($loop->last, 'hr.application.approve-applicant-modal')
+								</form>
+							@endif
+						</div>
+						@include('hr.round-guide-modal', ['round' => $applicationRound->round])
+						@includeWhen($applicationRound->round_status && !$applicationRound->mail_sent, 'hr.round-review-mail-modal', ['applicantRound' => $applicationRound])
+						@include('hr.application.application-evaluation', ['round' => $applicationRound->round])
+					@endforeach
+				@endif
+			</div>  
+		</div>
+	</div>
 </div>
 @endsection

--- a/resources/views/settings/hr/index.blade.php
+++ b/resources/views/settings/hr/index.blade.php
@@ -13,6 +13,7 @@
 	@include('settings.hr.no-show')
 	@include('settings.hr.approve')
 	@include('settings.hr.offer-letter')
+	@include('settings.hr.on-hold')
 	<h4 class="mt-5">Mail templates for rounds</h4>
 	@foreach ($rounds as $index => $round)
 		@foreach ($roundMailTypes as $type)

--- a/resources/views/settings/hr/on-hold.blade.php
+++ b/resources/views/settings/hr/on-hold.blade.php
@@ -1,0 +1,30 @@
+<div class="card mt-4">
+	<form action="{{ url('/settings/hr/update') }}" method="POST">
+
+		{{ csrf_field() }}
+		<div class="card-header c-pointer" data-toggle="collapse" data-target="#on_hold_email_template" aria-expanded="true" aria-controls="no_show_email_template">On hold email to applicant</div>
+		<div id="on_hold_email_template" class="collapse">
+			<div class="card-body">
+				<div class="form-row">
+					<div class="col-md-12">
+						<div class="form-group">
+							<label for="setting_key[application_on_hold_subject]">Subject</label>
+							<input type="text" name="setting_key[application_on_hold_subject]" class="form-control" value="{{ isset($settings['application_on_hold_subject']->setting_value) ? $settings['application_on_hold_subject']->setting_value : '' }}">
+						</div>
+					</div>
+				</div>
+				<div class="form-row">
+					<div class="col-md-12">
+						<div class="form-group">
+							<label for="setting_key[application_on_hold_body]">Mail body:</label>
+							<textarea name="setting_key[application_on_hold_body]" rows="10" class="richeditor form-control" placeholder="Body">{{ isset($settings['application_on_hold_body']->setting_value) ? $settings['application_on_hold_body']->setting_value : '' }}</textarea>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="card-footer">
+				<button type="submit" class="btn btn-primary">Save</button>
+			</div>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
Targets #1542 

### Description
- A "put on hold" button has been added to the edit application page.
- Width of the dropdown has been adjusted
- On putting the application "on hold", the user is redirected back to the open application page and the application is moved to the on-hold page with an "On hold" label status
- Also the applicant is sent an email that his/her application has been put on Hold

### Checklist
- [x] I have performed a self-review of my code