### PR TITLE
Disable save button in add category popup on guidelines page 

### DIFF
--- a/Modules/HR/Resources/views/guidelines-resources/create-category-modal.blade.php
+++ b/Modules/HR/Resources/views/guidelines-resources/create-category-modal.blade.php
@@ -9,13 +9,22 @@
                     @csrf
                     <div class="mb-3">
                         <label for="name" class="form-label">Category Name<strong class="text-danger">*</strong></label>
-                        <input type="text" class="form-control" id="name" name="name" required>
+                        <input type="text" class="form-control" id="name" onkeyup="success()" name="name" required>
                     </div>
                 </form>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" form="create-form" id="save-btn-action">Save</button>
+                <button type="button" class="btn btn-primary" form="create-form" id="save-btn-action" disabled>Save</button>
             </div>
         </div>
     </div>
 </div>
+<script>
+    function success() {
+	 if(document.getElementById("name").value=="") { 
+            document.getElementById('save-btn-action').disabled = true; 
+        } else { 
+            document.getElementById('save-btn-action').disabled = false;
+        }
+    }
+</script>

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -25,7 +25,7 @@
                 @endcan
                 <a class="dropdown-item" href="{{route('userappointmentslots.show',auth()->id())}}">Appointment Slots</a>
                 <a class="dropdown-item" href="{{ route('hr.tags.index') }}">{{ __('Manage Tags') }}</a>
-                <a class="dropdown-item disabled" href="{{ route('resources.index') }}">Guidelines And Resources</a>
+                <a class="dropdown-item" href="{{ route('resources.index') }}">Guidelines And Resources</a>
             </div>
         </li>
     @endif


### PR DESCRIPTION
 #1713
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->

<!--- Please complete the following steps and check these boxes before filing your PR: -->

### Description
Disabled save button in add category popup on guidelines page.
Added a function in category.modal.blade.php file that is checking whether the text in the form tab is empty or not and enabling/disabling the button accordingly .

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
