### PR TITLE
Contract file name is aligned in UI view

### DIFF
--- a/Modules/Project/Resources/views/subviews/edit-project-details.blade.php
+++ b/Modules/Project/Resources/views/subviews/edit-project-details.blade.php
@@ -92,8 +92,8 @@
                             </a>
                         @endif
                         <div class="custom-file mb-3">
-                            <input type="file" id="contract_file" name="contract_file" class="custom-file-input">
-                            <label for="contract" class="custom-file-label">Upload New Contract</label>
+                            <input type="file" id="contract_file" name="contract_file"  class="custom-file-input">
+                            <label for="contract_file" class="custom-file-label  overflow-hidden" >Upload New Contract</label>
                         </div>
                     </div>
                 </div>

--- a/Modules/Project/Resources/views/subviews/edit-project-details.blade.php
+++ b/Modules/Project/Resources/views/subviews/edit-project-details.blade.php
@@ -92,8 +92,8 @@
                             </a>
                         @endif
                         <div class="custom-file mb-3">
-                            <input type="file" id="contract_file" name="contract_file"  class="custom-file-input">
-                            <label for="contract_file" class="custom-file-label  overflow-hidden" >Upload New Contract</label>
+                            <input type="file" id="contract_file" name="contract_file" class="custom-file-input">
+                            <label for="contract_file" class="custom-file-label overflow-hidden" >Upload New Contract</label>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
#1687

### Description
In Modules/Project/Resources/views/subviews/edit-project-details.blade.php I have changed line 96 to <label for="contract_file" class="custom-file-label  overflow-hidden">. Here, I have added overflow-hidden in class and changed "contract" to "contract-file". This is inside <div class="custom-file mb-3">.
These changes are required to align the contract file name in UI view upon uploading the contract file. 

- [x] I have performed a self-review of my own code.
