### PR TITLE
Commented out email functionality

### DIFF
--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -174,7 +174,8 @@ class ApplicationRound extends Model
                 $body->setting_value = str_replace(config('constants.hr.template-variables.applicant-name'), $applicant->name, $body->setting_value);
                 $body->setting_value = str_replace(config('constants.hr.template-variables.job-title'), $job_title, $body->setting_value);
 
-                Mail::to($applicant->email, $applicant->name)->send(new OnHold($subject->setting_value, $body->setting_value));
+                //ToDo: We need to think of what would be the worfklow once an application is put on hold by HR team.
+                // Mail::to($applicant->email, $applicant->name)->send(new OnHold($subject->setting_value, $body->setting_value));
 
                 return redirect()->route('applications.job.index');
 


### PR DESCRIPTION
After putting an application on hold, we need to think of the workflow. The mail going to candidates is not needed anymore. Till the time there is thought process is in place. The mail trigger is prevented.