### PR TITLE
Added a margin between book title and setting button

### DIFF
--- a/resources/views/knowledgecafe/library/books/index.blade.php
+++ b/resources/views/knowledgecafe/library/books/index.blade.php
@@ -51,7 +51,7 @@
                     <a  :href="updateRoute+ '/'+ book.id">
                         <img :src="book.thumbnail" class="cover_image" >
                     </a>
-                    <div class="pl-2 pr-3">
+                    <div class="pl-2 pr-3 mr-1">
                         <a  :href="updateRoute+ '/'+ book.id" class="card-title font-weight-bold mb-1 h6" :title="book.title">@{{ strLimit(book.title, 35) }}</a>
                         <p class="text-dark" :title="book.author">@{{ strLimit(book.author, 20) }} </p>
                         


### PR DESCRIPTION
#1775 

### Description
Addition of right margin to book title div to add some gap between the book title and the settings button.

- [x] I have performed a self-review of my own code.
