### PR TITLE
Modified the send confirmation mail functionality

### DIFF
--- a/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
@@ -16,7 +16,7 @@
             </div>
         </div>
 
-        <div class="form-row mb-4">
+        <div class="form-row mb-1">
             <div class="col-md-5">
                 <div>
                     <h4><b>Invoice Information:</b></h4>

--- a/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
@@ -16,7 +16,7 @@
             </div>
         </div>
 
-        <div class="form-row mb-1">
+        <div class="form-row mb-4">
             <div class="col-md-5">
                 <div>
                     <h4><b>Invoice Information:</b></h4>
@@ -160,11 +160,12 @@
                     <textarea name="comments" id="comments" rows="5" class="form-control" v-model="comments"></textarea>
                 </div>
             </div>
-            <div class="d-flex" v-if="status == 'paid'">
+            <div v-if="status == 'paid'">
                 @if($invoice->payment_confirmation_mail_sent === 0)
                     <input type="checkbox" id="showEmail" class="ml-auto" name="send_mail">
                     <label for="showEmail" class="mx-1 pt-1">{{ __('Send Confirmation Mail') }}</label>
                     <i class="pt-1 ml-1 fa fa-external-link-square" data-toggle="modal" data-target="#paymentReceived"></i>
+                    <div><small>{{ __('If disabled the mail will not be sent.') }}<small></div>
                 @else
                     <label class="mx-1 pt-1">
                         {{ __('Confirmation Mail Status: ') }}
@@ -175,7 +176,6 @@
                 @endif
             </div> 
         </div>
-        <div v-if="show_on_select"> <h6>{{ __('If disabled the mail will not be sent.') }}</h6></div>
         <div>
             @include('invoice::modals.payment-received')
         </div>

--- a/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
@@ -161,18 +161,18 @@
                 </div>
             </div>
             <div class="d-flex" v-if="status == 'paid'">
-                    @if($invoice->payment_confirmation_mail_sent === 0)
+                @if($invoice->payment_confirmation_mail_sent === 0)
                     <input type="checkbox" id="showEmail" class="ml-auto" @change="showEmail($event)" name="send_mail">
                     <label for="showEmail" class="mx-1 pt-1">{{ __('Send Confirmation Mail') }}</label>
                     <i class="pt-1 ml-1 fa fa-external-link-square" data-toggle="modal" data-target="#paymentReceived"></i>
-                    @else
+                @else
                     <label class="mx-1 pt-1">
                         {{ __('Confirmation Mail Status: ') }}
                         <span class="text-success font-weight-bold">
                             {{ __('Sent') }}
                         </span>
                     </label>
-                    @endif
+                @endif
             </div> 
         </div>
         <div v-if="show_on_select">Mail not sent</div>

--- a/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
@@ -161,20 +161,21 @@
                 </div>
             </div>
             <div class="d-flex" v-if="status == 'paid'">
-                @if($invoice->payment_confirmation_mail_sent === 0)
+                    @if($invoice->payment_confirmation_mail_sent === 0)
                     <input type="checkbox" id="showEmail" class="ml-auto" @change="showEmail($event)" name="send_mail">
                     <label for="showEmail" class="mx-1 pt-1">{{ __('Send Confirmation Mail') }}</label>
-                    <i v-if="show_on_select" class="pt-1 ml-1 fa fa-external-link-square" data-toggle="modal" data-target="#paymentReceived"></i>
-                @else
+                    <i class="pt-1 ml-1 fa fa-external-link-square" data-toggle="modal" data-target="#paymentReceived"></i>
+                    @else
                     <label class="mx-1 pt-1">
                         {{ __('Confirmation Mail Status: ') }}
                         <span class="text-success font-weight-bold">
                             {{ __('Sent') }}
                         </span>
                     </label>
-                @endif
-            </div>
+                    @endif
+            </div> 
         </div>
+        <div v-if="show_on_select">Mail not sent</div>
         <div>
             @include('invoice::modals.payment-received')
         </div>
@@ -227,9 +228,10 @@
 
         showEmail($event) {
             if (event.target.checked) {
-                this.show_on_select = true
-            } else {
                 this.show_on_select = false
+            } else {
+                this.show_on_select = true
+               
             }
         }
     },

--- a/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
@@ -162,7 +162,7 @@
             </div>
             <div class="d-flex" v-if="status == 'paid'">
                 @if($invoice->payment_confirmation_mail_sent === 0)
-                    <input type="checkbox" id="showEmail" class="ml-auto" @change="showEmail($event)" name="send_mail">
+                    <input type="checkbox" id="showEmail" class="ml-auto" name="send_mail">
                     <label for="showEmail" class="mx-1 pt-1">{{ __('Send Confirmation Mail') }}</label>
                     <i class="pt-1 ml-1 fa fa-external-link-square" data-toggle="modal" data-target="#paymentReceived"></i>
                 @else
@@ -175,7 +175,7 @@
                 @endif
             </div> 
         </div>
-        <div v-if="show_on_select">Mail not sent</div>
+        <div v-if="show_on_select"> <h6>{{ __('If disabled the mail will not be sent.') }}</h6></div>
         <div>
             @include('invoice::modals.payment-received')
         </div>
@@ -225,15 +225,6 @@
         updateBankCharges() {
             this.bank_charges = this.amount - this.amount_paid
         },
-
-        showEmail($event) {
-            if (event.target.checked) {
-                this.show_on_select = false
-            } else {
-                this.show_on_select = true
-               
-            }
-        }
     },
 
     data() {

--- a/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
+++ b/Modules/Invoice/Resources/views/subviews/edit/invoice-details.blade.php
@@ -165,7 +165,7 @@
                     <input type="checkbox" id="showEmail" class="ml-auto" name="send_mail">
                     <label for="showEmail" class="mx-1 pt-1">{{ __('Send Confirmation Mail') }}</label>
                     <i class="pt-1 ml-1 fa fa-external-link-square" data-toggle="modal" data-target="#paymentReceived"></i>
-                    <div><small>{{ __('If disabled the mail will not be sent.') }}<small></div>
+                    <div class="fz-14 text-theme-orange">{{ __('If disabled the mail will not be sent.') }}</div>
                 @else
                     <label class="mx-1 pt-1">
                         {{ __('Confirmation Mail Status: ') }}


### PR DESCRIPTION
 #1805


### Description:
Made the arrow tooltip available next to Send Confirmation Mail, whether checkbox is enabled or disabled, displayed a message as Mail not sent when checkbox is disabled below the Send Confirmation Mail. 

### Checklist:

- [x] I have performed a self-review of my own code.
