### PR TITLE
Added email validation for CC and BCC field available in the email body

### DIFF
--- a/Modules/Invoice/Resources/views/modals/invoice-reminder.blade.php
+++ b/Modules/Invoice/Resources/views/modals/invoice-reminder.blade.php
@@ -34,7 +34,7 @@
                                     <i class="fa fa-question-circle"></i>
                                 </span>
                             </label>
-                            <input type="text" name="cc" id="cc" class="form-control" value="{{ config('invoice.mail.send-invoice.email') }}">
+                            <input type="email" name="cc" id="cc" class="form-control" value="{{ config('invoice.mail.send-invoice.email') }}">
                         </div>
                         <div class="form-group col-md-12">
                             <label class="leading-none" for="bcc">
@@ -43,7 +43,7 @@
                                     <i class="fa fa-question-circle"></i>
                                 </span>
                             </label>
-                            <input type="text" name="bcc" id="bcc" class="form-control" value="">
+                            <input type="email" name="bcc" id="bcc" class="form-control" value="{{ config('invoice.mail.send-invoice.email') }}">
                         </div>
                         <div class="form-group col-md-12">
                             <label class="leading-none" for="emailSubject">{{ __('Subject') }}</label>

--- a/Modules/Invoice/Resources/views/modals/invoice-reminder.blade.php
+++ b/Modules/Invoice/Resources/views/modals/invoice-reminder.blade.php
@@ -43,7 +43,7 @@
                                     <i class="fa fa-question-circle"></i>
                                 </span>
                             </label>
-                            <input type="email" name="bcc" id="bcc" class="form-control" value="{{ config('invoice.mail.send-invoice.email') }}">
+                            <input type="email" name="bcc" id="bcc" class="form-control" value="">
                         </div>
                         <div class="form-group col-md-12">
                             <label class="leading-none" for="emailSubject">{{ __('Subject') }}</label>


### PR DESCRIPTION
Targets #2174 


### Description
Added email validation for CC and BCC field available in the invoice reminder email body.

### Checklist:

- [x] I have performed a self-review of my own code.
