### PR TITLE
 Task 2155 INTERVIEW DURATION

### DIFF
--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -55,8 +55,10 @@ class ApplicationRound extends Model
                 if ($application->isNoShow() && Carbon::parse($attr['scheduled_date'])->gt(now())) {
                     $application->markInProgress();
                 }
+                $date = $attr['scheduled_date'];
+                $time = $attr['scheduled_time'];
                 $fillable = [
-                    'scheduled_date' => $attr['scheduled_date'],
+                    'scheduled_date' => "$date . $time",
                     'scheduled_person_id' => $attr['scheduled_person_id'],
                 ];
                 $attr['reviews'] = [];

--- a/Modules/HR/Entities/ApplicationRound.php
+++ b/Modules/HR/Entities/ApplicationRound.php
@@ -28,7 +28,7 @@ class ApplicationRound extends Model
 
     public $timestamps = false;
 
-    protected $dates = ['scheduled_date', 'conducted_date'];
+    protected $dates = ['scheduled_date', 'conducted_date', 'meeting_duration'];
 
     public static function newFactory()
     {

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -36,16 +36,10 @@ abstract class ApplicationController extends Controller
         $this->service = $service;
     }
 
-    public function finish(Request $request)
+    public function markInterviewFinished(Request $request)
     {
         $ApplicationRound = ApplicationRound::find($request->documentId);
-        $meetDate = Carbon::parse($request->duration);
-        $scheduleDate = Carbon::parse($ApplicationRound->scheduled_date);
-        $interval = $meetDate->diff($scheduleDate);
-        $meetDuration = $interval->format('%H:%i:%s');
-        $meet_Duration = Carbon::parse($meetDuration);
-        $ApplicationRound->meeting_duration = $meet_Duration;
-        $ApplicationRound->save();
+        $this->service->markInterviewFinished($ApplicationRound);
 
         return response()->json([
             'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -3,7 +3,6 @@
 namespace Modules\HR\Http\Controllers\Recruitment;
 
 use App\Helpers\FileHelper;
-use DateTime;
 use App\Models\Setting;
 use App\Models\Tag;
 use Carbon\Carbon;

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -5,6 +5,7 @@ namespace Modules\HR\Http\Controllers\Recruitment;
 use App\Helpers\FileHelper;
 use App\Models\Setting;
 use App\Models\Tag;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Mail;
@@ -44,7 +45,7 @@ abstract class ApplicationController extends Controller
             'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),
         ]);
     }
-
+    
     /**
      * Display a listing of the resource.
      */

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -5,7 +5,6 @@ namespace Modules\HR\Http\Controllers\Recruitment;
 use App\Helpers\FileHelper;
 use App\Models\Setting;
 use App\Models\Tag;
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Mail;
@@ -45,6 +44,7 @@ abstract class ApplicationController extends Controller
             'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),
         ]);
     }
+
     /**
      * Display a listing of the resource.
      */

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -46,6 +46,7 @@ abstract class ApplicationController extends Controller
         $meet_Duration = new DateTime($meetDuration);
         $ApplicationRound->meeting_duration = $meet_Duration;
         $ApplicationRound->save();
+        
         return response()->json([
             'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),
         ]);

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -46,7 +46,7 @@ abstract class ApplicationController extends Controller
         $meet_Duration = new DateTime($meetDuration);
         $ApplicationRound->meeting_duration = $meet_Duration;
         $ApplicationRound->save();
-        
+
         return response()->json([
             'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),
         ]);

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -44,10 +44,10 @@ abstract class ApplicationController extends Controller
         $interval = $meetDate->diff($scheduleDate);
         $meetDuration = $interval->format('%H:%i:%s');
         $meet_Duration = new DateTime($meetDuration);
-        $ApplicationRound->meeting_duration= $meet_Duration;
+        $ApplicationRound->meeting_duration = $meet_Duration;
         $ApplicationRound->save();
         return response()->json([
-          'status'=>200, 'meet_duration'=> $ApplicationRound->meeting_duration->format('H:i:s'),
+            'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),
         ]);
     }
     /**

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -6,6 +6,7 @@ use App\Helpers\FileHelper;
 use DateTime;
 use App\Models\Setting;
 use App\Models\Tag;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Mail;
@@ -39,11 +40,11 @@ abstract class ApplicationController extends Controller
     public function finish(Request $request)
     {
         $ApplicationRound = ApplicationRound::find($request->documentId);
-        $meetDate = new DateTime($request->duration);
-        $scheduleDate = new DateTime($ApplicationRound->scheduled_date);
+        $meetDate = Carbon::parse($request->duration);
+        $scheduleDate = Carbon::parse($ApplicationRound->scheduled_date);
         $interval = $meetDate->diff($scheduleDate);
         $meetDuration = $interval->format('%H:%i:%s');
-        $meet_Duration = new DateTime($meetDuration);
+        $meet_Duration = Carbon::parse($meetDuration);
         $ApplicationRound->meeting_duration = $meet_Duration;
         $ApplicationRound->save();
 

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -5,7 +5,6 @@ namespace Modules\HR\Http\Controllers\Recruitment;
 use App\Helpers\FileHelper;
 use App\Models\Setting;
 use App\Models\Tag;
-use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Mail;
@@ -45,7 +44,7 @@ abstract class ApplicationController extends Controller
             'status' => 200, 'meet_duration' => $ApplicationRound->meeting_duration->format('H:i:s'),
         ]);
     }
-    
+
     /**
      * Display a listing of the resource.
      */

--- a/Modules/HR/Http/Requests/Recruitment/ApplicationRoundRequest.php
+++ b/Modules/HR/Http/Requests/Recruitment/ApplicationRoundRequest.php
@@ -28,6 +28,7 @@ class ApplicationRoundRequest extends FormRequest
             'action' => 'required|string',
             'refer_to' => 'nullable|string|required_if:action,refer',
             'scheduled_date' => 'nullable|date',
+            'scheduled_time' => 'nullable|date_format:H:i',
             'scheduled_person_id' => 'nullable|integer',
             'next_round' => 'nullable|string|required_if:action,confirm',
             'create_calendar_event' => 'nullable|filled',

--- a/Modules/HR/Routes/web.php
+++ b/Modules/HR/Routes/web.php
@@ -90,6 +90,7 @@ Route::middleware('auth')->group(function () {
             Route::get('{application}/get-offer-letter', 'JobApplicationController@getOfferLetter')->name('applications.getOfferLetter');
             Route::post('{application}/sendmail', 'JobApplicationController@sendApplicationMail')->name('application.custom-email');
             Route::post('/teaminteraction', 'JobApplicationController@generateTeamInteractionEmail');
+            Route::get('/finishinterview', 'JobApplicationController@finish')->name('finishinterview');
 
             Route::resource('internship', 'InternshipApplicationController')
                 ->only(['index', 'edit'])

--- a/Modules/HR/Routes/web.php
+++ b/Modules/HR/Routes/web.php
@@ -90,7 +90,7 @@ Route::middleware('auth')->group(function () {
             Route::get('{application}/get-offer-letter', 'JobApplicationController@getOfferLetter')->name('applications.getOfferLetter');
             Route::post('{application}/sendmail', 'JobApplicationController@sendApplicationMail')->name('application.custom-email');
             Route::post('/teaminteraction', 'JobApplicationController@generateTeamInteractionEmail');
-            Route::get('/finishinterview', 'JobApplicationController@finish')->name('finishinterview');
+            Route::get('/finishinterview', 'JobApplicationController@markInterviewFinished')->name('markInterviewFinished');
 
             Route::resource('internship', 'InternshipApplicationController')
                 ->only(['index', 'edit'])

--- a/Modules/HR/Services/ApplicationService.php
+++ b/Modules/HR/Services/ApplicationService.php
@@ -97,12 +97,12 @@ class ApplicationService implements ApplicationServiceContract
 
     public function markInterviewFinished($data)
     {
-    $MeetDate = Carbon::parse($data->duration);
-    $ScheduleDate = Carbon::parse($data->scheduled_date);
-    $Interval = $MeetDate->diffAsCarbonInterval($ScheduleDate);
-    $MeetDuration = $Interval->format('%H:%i:%s');
-    $MeetDuration = Carbon::parse($MeetDuration);
-    $data->meeting_duration = $MeetDuration;
-    $data->save();
+        $MeetDate = Carbon::parse($data->duration);
+        $ScheduleDate = Carbon::parse($data->scheduled_date);
+        $Interval = $MeetDate->diffAsCarbonInterval($ScheduleDate);
+        $MeetDuration = $Interval->format('%H:%i:%s');
+        $MeetDuration = Carbon::parse($MeetDuration);
+        $data->meeting_duration = $MeetDuration;
+        $data->save();
     }
 }

--- a/Modules/HR/Services/ApplicationService.php
+++ b/Modules/HR/Services/ApplicationService.php
@@ -4,6 +4,7 @@ namespace Modules\HR\Services;
 
 use Module;
 use App\Models\Tag;
+use Carbon\Carbon;
 use Modules\HR\Entities\Job;
 use Modules\User\Entities\User;
 use Modules\HR\Entities\Applicant;
@@ -92,5 +93,16 @@ class ApplicationService implements ApplicationServiceContract
         // call event that triggers send custom application mail
         $data['mail_sender_name'] = $data['mail_sender_name'] ?? auth()->user()->name;
         event(new CustomMailTriggeredForApplication($application, $data));
+    }
+
+    public function markInterviewFinished($data)
+    {
+    $MeetDate = Carbon::parse($data->duration);
+    $ScheduleDate = Carbon::parse($data->scheduled_date);
+    $Interval = $MeetDate->diffAsCarbonInterval($ScheduleDate);
+    $MeetDuration = $Interval->format('%H:%i:%s');
+    $MeetDuration = Carbon::parse($MeetDuration);
+    $data->meeting_duration = $MeetDuration;
+    $data->save();
     }
 }

--- a/database/migrations/2022_08_29_114532_create_meeting_duration_column.php
+++ b/database/migrations/2022_08_29_114532_create_meeting_duration_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMeetingDurationColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_application_round', function (Blueprint $table) {
+            $table->timestamp('meeting_duration')->nullable()->after('scheduled_end');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_application_round', function (Blueprint $table) {
+            $table->dropColumn(['meeting_duration']);
+        });
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1786,20 +1786,20 @@ $("#interactionErrorModalCloseBtn").click(function () {
 	$("#InteractionError").toggleClass("d-none");
 });
 
-$(document).on("click", ".finish_interview", function(e) {
-  e.preventDefault();
-  var dID = $(".finish_interview").val();
-  $("#meeting_time").hide();
-  var duration = new Date().toLocaleString();
-  $.ajax({
-    type: "GET",
-    url: "/hr/recruitment/finishinterview",
-    data: { documentId: dID, duration: duration },
-    dataType: "json",
-    success: function(response) {
-      console.log(response.meet_duration);
-      $("#meet_time").hide();
-      $("#meeting_time").show();
-    },
-  });
+$(document).on("click", ".finish_interview", function (e) {
+	e.preventDefault();
+	var dID = $(".finish_interview").val();
+	$("#meeting_time").hide();
+	var duration = new Date().toLocaleString();
+	$.ajax({
+		type: "GET",
+		url: "/hr/recruitment/finishinterview",
+		data: { documentId: dID, duration: duration },
+		dataType: "json",
+		success: function (response) {
+			console.log(response.meet_duration);
+			$("#meet_time").hide();
+			$("#meeting_time").show();
+		},
+	});
 });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -19,6 +19,7 @@ Vue.use(Laue);
 // vue toast registration
 import Toast from "vue-toastification";
 import "vue-toastification/dist/index.css";
+import moment from "moment";
 const options = {
 	timeout: 2000
 };
@@ -1789,8 +1790,8 @@ $("#interactionErrorModalCloseBtn").click(function () {
 $(document).on("click", ".finish_interview", function (e) {
 	e.preventDefault();
 	var dID = $(".finish_interview").val();
-	$("#meeting_time").hide();
-	var duration = new Date().toLocaleString();
+	$("#meetingTime").hide();
+	var duration = moment().format('YYYY/MM/DD H:m:s');
 	$.ajax({
 		type: "GET",
 		url: "/hr/recruitment/finishinterview",
@@ -1799,7 +1800,7 @@ $(document).on("click", ".finish_interview", function (e) {
 		success: function (response) {
 			console.log(response.meet_duration);
 			$("#meet_time").hide();
-			$("#meeting_time").show();
+			$("#meetingTime").show();
 		},
 	});
 });

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1785,3 +1785,21 @@ $("#updateEmail").on("click", function () {
 $("#interactionErrorModalCloseBtn").click(function () {
 	$("#InteractionError").toggleClass("d-none");
 });
+
+$(document).on("click", ".finish_interview", function(e) {
+  e.preventDefault();
+  var dID = $(".finish_interview").val();
+  $("#meeting_time").hide();
+  var duration = new Date().toLocaleString();
+  $.ajax({
+    type: "GET",
+    url: "/hr/recruitment/finishinterview",
+    data: { documentId: dID, duration: duration },
+    dataType: "json",
+    success: function(response) {
+      console.log(response.meet_duration);
+      $("#meet_time").hide();
+      $("#meeting_time").show();
+    },
+  });
+});

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1791,7 +1791,7 @@ $(document).on("click", ".finish_interview", function (e) {
 	e.preventDefault();
 	var dID = $(".finish_interview").val();
 	$("#meetingTime").hide();
-	var duration = moment().format('YYYY/MM/DD H:m:s');
+	var duration = moment().format("YYYY/MM/DD H:m:s");
 	$.ajax({
 		type: "GET",
 		url: "/hr/recruitment/finishinterview",

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -105,19 +105,17 @@
                                                             {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
                                                     @endif
                                                 </div>
-                                                @if ($applicationRound->scheduled_date)
-                                                    @if ($applicationRound->hangout_link)
+                                                @if ($applicationRound->scheduled_date && $applicationRound->hangout_link)
                                                         @if($applicationRound->meeting_duration!= NULL)
-                                                            <input type="Text" readonly="readonly" name="meeting_time"
-                                                            id="meeting_time"
+                                                            <input type="Text" readonly="readonly" name="meetingTime"
+                                                            id="meetingTime"
                                                             class="form-control form-control-sm"
                                                             value="{{"$applicationRound->meeting_duration"}}">
                                                         @else
-                                                            <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
-                                                            <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
-                                                            id="meeting_time" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
+                                                            <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-0 px-0 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
+                                                            <input type="Text" style="display: none;" readonly="readonly" name="meetingTime"
+                                                            id="meetingTime" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
                                                         @endif
-                                                    @endif
                                                 @endif
                                                 <div class="icon-pencil position-relative ml-3 c-pointer"
                                                     data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}">
@@ -430,19 +428,17 @@
                                                     @endif
                                                 </div>
 
-                                                @if ($applicationRound->scheduled_date)
-                                                    @if ($applicationRound->hangout_link)
+                                                @if ($applicationRound->scheduled_date && $applicationRound->hangout_link)
                                                         @if($applicationRound->meeting_duration!= NULL)
-                                                            <input type="Text" readonly="readonly" name="meeting_time"
-                                                            id="meeting_time"
+                                                            <input type="Text" readonly="readonly" name="meetingTime"
+                                                            id="meetingTime"
                                                             class="form-control form-control-sm"
                                                             value="{{"$applicationRound->meeting_duration"}}">
                                                         @else
-                                                            <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
-                                                            <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
-                                                            id="meeting_time"class="form-control form-control-sm"value="{{"$applicationRound->meeting_duration"}}">
+                                                            <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-0 px-0 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
+                                                            <input type="Text" style="display: none;" readonly="readonly" name="meetingTime"
+                                                            id="meetingTime" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
                                                         @endif
-                                                    @endif
                                                 @endif
                                                 <div class="icon-pencil position-relative ml-3 c-pointer"
                                                     data-toggle="collapse"
@@ -951,18 +947,16 @@
                                                     {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
                                             @endif
                                         </div>
-                                         @if ($applicationRound->scheduled_date)
-                                                @if ($applicationRound->hangout_link)
-                                                    @if($applicationRound->meeting_duration!= NULL)
-                                                        <input type="Text" readonly="readonly" name="meeting_time"
-                                                        id="meeting_time"
-                                                        class="form-control form-control-sm"
-                                                        value="{{"$applicationRound->meeting_duration"}}">
-                                                        @else
-                                                        <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
-                                                        <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
-                                                        id="meeting_time" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
-                                                  @endif
+                                            @if ($applicationRound->scheduled_date && $applicationRound->hangout_link)
+                                                @if($applicationRound->meeting_duration!= NULL)
+                                                    <input type="Text" readonly="readonly" name="meetingTime"
+                                                    id="meetingTime"
+                                                    class="form-control form-control-sm"
+                                                    value="{{"$applicationRound->meeting_duration"}}">
+                                                @else
+                                                    <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-0 px-0 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
+                                                    <input type="Text" style="display: none;" readonly="readonly" name="meetingTime"
+                                                    id="meetingTime" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
                                                 @endif
                                             @endif
                                         <div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse"
@@ -1234,15 +1228,15 @@
                                                             </label>
                                                             @if ($applicationRound->scheduled_date)
                                                             @php
-                                                                $date1 = new DateTime($applicationRound->scheduled_date);
-                                                                $date2 = new DateTime($applicationRound->scheduled_end);
-                                                                $time_diff = $date2->diff($date1);
-                                                                $time=($time_diff->days * 24) + $time_diff->h;
+                                                                $ScheduleDate = new DateTime($applicationRound->scheduled_date);
+                                                                $ScheduleEnd = new DateTime($applicationRound->scheduled_end);
+                                                                $TimeDiff = $ScheduleEnd->diff($ScheduleDate);
+                                                                $Time=($TimeDiff->days * 24) + $TimeDiff->h;
                                                             @endphp
                                                                 <input type="Text" readonly="readonly" name="expected_time"
                                                                     id="expected_time"
                                                                     class="form-control form-control-sm"
-                                                                    value="{{"$time hours"}}">
+                                                                    value="{{"$Time hours"}}">
                                                             @endif
                                                         </div>
                                                             <div class="form-group col-md-4">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -949,11 +949,11 @@
                                         </div>
                                             @if ($applicationRound->scheduled_date && $applicationRound->hangout_link)
                                                 @if($applicationRound->meeting_duration!= NULL)
-                                                    {{-- <input type="Text" readonly="readonly" name="meetingTime"
+                                                    <input type="Text" readonly="readonly" name="meetingTime"
                                                     id="meetingTime"
                                                     class="form-control form-control-sm"
                                                     value="{{"$applicationRound->meeting_duration"}}">
-                                                @else --}}
+                                                @else
                                                     <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-0 px-0 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
                                                     <input type="Text" style="display: none;" readonly="readonly" name="meetingTime"
                                                     id="meetingTime" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -949,11 +949,11 @@
                                         </div>
                                             @if ($applicationRound->scheduled_date && $applicationRound->hangout_link)
                                                 @if($applicationRound->meeting_duration!= NULL)
-                                                    <input type="Text" readonly="readonly" name="meetingTime"
+                                                    {{-- <input type="Text" readonly="readonly" name="meetingTime"
                                                     id="meetingTime"
                                                     class="form-control form-control-sm"
                                                     value="{{"$applicationRound->meeting_duration"}}">
-                                                @else
+                                                @else --}}
                                                     <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-0 px-0 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
                                                     <input type="Text" style="display: none;" readonly="readonly" name="meetingTime"
                                                     id="meetingTime" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -954,11 +954,11 @@
                                          @if ($applicationRound->scheduled_date)
                                                 @if ($applicationRound->hangout_link)
                                                     @if($applicationRound->meeting_duration!= NULL)
-                                                        {{-- <input type="Text" readonly="readonly" name="meeting_time"
+                                                        <input type="Text" readonly="readonly" name="meeting_time"
                                                         id="meeting_time"
                                                         class="form-control form-control-sm"
                                                         value="{{"$applicationRound->meeting_duration"}}">
-                                                        @else --}}
+                                                        @else
                                                         <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
                                                         <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
                                                         id="meeting_time" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -138,7 +138,7 @@
                                                         <div class="form-row">
                                                             <div class="form-group col-md-4">
                                                                 <label for="scheduled_date"
-                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    class="fz-12 leading-none text-secondary w-100p">
                                                                     <div>
                                                                         <i class="fa fa-calendar" aria-hidden="true"></i>
                                                                         <span>Scheduled date</span>
@@ -658,7 +658,7 @@
                                                         <div class="form-row">
                                                             <div class="form-group col-md-4">
                                                                 <label for="scheduled_date"
-                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    class="fz-12 leading-none text-secondary w-100p">
                                                                     <div>
                                                                         <i class="fa fa-calendar" aria-hidden="true"></i>
                                                                         <span>Scheduled date</span>
@@ -954,11 +954,11 @@
                                          @if ($applicationRound->scheduled_date)
                                                 @if ($applicationRound->hangout_link)
                                                     @if($applicationRound->meeting_duration!= NULL)
-                                                        <input type="Text" readonly="readonly" name="meeting_time"
+                                                        {{-- <input type="Text" readonly="readonly" name="meeting_time"
                                                         id="meeting_time"
                                                         class="form-control form-control-sm"
                                                         value="{{"$applicationRound->meeting_duration"}}">
-                                                        @else
+                                                        @else --}}
                                                         <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
                                                         <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
                                                         id="meeting_time" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
@@ -1183,7 +1183,7 @@
                                                         @if ($application->latestApplicationRound->round->name != "Telephonic Interview"  && $applicationRound->round->name != "Team Interaction Round")
                                                             <div class="form-group col-md-4">
                                                                 <label for="scheduled_date"
-                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    class="fz-12 leading-none text-secondary w-100p">
                                                                     <div>
                                                                         <i class="fa fa-calendar" aria-hidden="true"></i>
                                                                         <span>Scheduled date</span>
@@ -1225,7 +1225,7 @@
                                                                     value="{{ $applicationRound->scheduled_date->toTimeString()}}">
                                                             @endif
                                                         </div>
-                                                        <div class="form-group col-md-4">
+                                                        <div class="form-group col-md-3">
                                                             <label for="expected_time"
                                                                 class="fz-14 leading-none text-secondary w-100p">
                                                                 <div>

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -105,6 +105,20 @@
                                                             {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
                                                     @endif
                                                 </div>
+                                                @if ($applicationRound->scheduled_date)
+                                                    @if ($applicationRound->hangout_link)
+                                                        @if($applicationRound->meeting_duration!= NULL)
+                                                            <input type="Text" readonly="readonly" name="meeting_time"
+                                                            id="meeting_time"
+                                                            class="form-control form-control-sm"
+                                                            value="{{"$applicationRound->meeting_duration"}}">
+                                                        @else
+                                                            <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
+                                                            <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
+                                                            id="meeting_time" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
+                                                        @endif
+                                                    @endif
+                                                @endif
                                                 <div class="icon-pencil position-relative ml-3 c-pointer"
                                                     data-toggle="collapse" data-target="#collapse_{{ $loop->iteration }}">
                                                     <i class="fa fa-pencil"></i>
@@ -122,7 +136,7 @@
                                                 <div class="card-body">
                                                     @if (!$applicationRound->round_status)
                                                         <div class="form-row">
-                                                            <div class="form-group col-md-5">
+                                                            <div class="form-group col-md-4">
                                                                 <label for="scheduled_date"
                                                                     class="fz-14 leading-none text-secondary w-100p">
                                                                     <div>
@@ -142,13 +156,41 @@
                                                                     </div>
                                                                 </label>
                                                                 @if ($applicationRound->scheduled_date)
-                                                                    <input type="datetime-local" name="scheduled_date"
+                                                                    <input type="date" name="scheduled_date"
                                                                         id="scheduled_date"
                                                                         class="form-control form-control-sm"
-                                                                        value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
+                                                                        value="{{ $applicationRound->scheduled_date->format(config('constants.date_format')) }}">
                                                                 @else
                                                                     <div class="fz-16 leading-tight">Pending calendar
                                                                         confirmation</div>
+                                                                @endif
+                                                            </div>
+                                                            <div class="form-group col-md-4">
+                                                                <label for="scheduled_time"
+                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    <div>
+                                                                        <span>Scheduled Time</span>
+                                                                    </div>
+                                                                </label>
+                                                                @if ($applicationRound->scheduled_date)
+                                                                    <input type="Time" name="scheduled_time"
+                                                                        id="scheduled_time"
+                                                                        class="form-control form-control-sm"
+                                                                        value="{{ $applicationRound->scheduled_date->toTimeString()}}">
+                                                                @endif
+                                                            </div>
+                                                            <div class="form-group col-md-4">
+                                                                <label for="expected_time"
+                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    <div>
+                                                                        <span>Expected End Time</span>
+                                                                    </div>
+                                                                </label>
+                                                                @if ($applicationRound->scheduled_date)
+                                                                    <input type="Time" readonly="readonly" name="scheduled_time"
+                                                                        id="scheduled_time"
+                                                                        class="form-control form-control-sm"
+                                                                        value="{{ $applicationRound->scheduled_date->toTimeString()}}">
                                                                 @endif
                                                             </div>
                                                             <div class="form-group col-md-4">
@@ -388,6 +430,20 @@
                                                     @endif
                                                 </div>
 
+                                                @if ($applicationRound->scheduled_date)
+                                                    @if ($applicationRound->hangout_link)
+                                                        @if($applicationRound->meeting_duration!= NULL)
+                                                            <input type="Text" readonly="readonly" name="meeting_time"
+                                                            id="meeting_time"
+                                                            class="form-control form-control-sm"
+                                                            value="{{"$applicationRound->meeting_duration"}}">
+                                                        @else
+                                                            <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
+                                                            <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
+                                                            id="meeting_time"class="form-control form-control-sm"value="{{"$applicationRound->meeting_duration"}}">
+                                                        @endif
+                                                    @endif
+                                                @endif
                                                 <div class="icon-pencil position-relative ml-3 c-pointer"
                                                     data-toggle="collapse"
                                                     data-target="#pre-trial-collapse_{{ $loop->iteration }}"><i
@@ -600,7 +656,7 @@
                                                 <div class="card-body">
                                                     @if (!$applicationRound->round_status)
                                                         <div class="form-row">
-                                                            <div class="form-group col-md-5">
+                                                            <div class="form-group col-md-4">
                                                                 <label for="scheduled_date"
                                                                     class="fz-14 leading-none text-secondary w-100p">
                                                                     <div>
@@ -620,13 +676,41 @@
                                                                     </div>
                                                                 </label>
                                                                 @if ($applicationRound->scheduled_date)
-                                                                    <input type="datetime-local" name="scheduled_date"
+                                                                    <input type="date" name="scheduled_date"
                                                                         id="scheduled_date"
                                                                         class="form-control form-control-sm"
-                                                                        value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
+                                                                        value="{{ $applicationRound->scheduled_date->format(config('constants.date_format')) }}">
                                                                 @else
                                                                     <div class="fz-16 leading-tight">Pending calendar
                                                                         confirmation</div>
+                                                                @endif
+                                                            </div>
+                                                            <div class="form-group col-md-4">
+                                                                <label for="scheduled_time"
+                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    <div>
+                                                                        <span>Scheduled Time</span>
+                                                                    </div>
+                                                                </label>
+                                                                @if ($applicationRound->scheduled_date)
+                                                                    <input type="Time" name="scheduled_time"
+                                                                        id="scheduled_time"
+                                                                        class="form-control form-control-sm"
+                                                                        value="{{ $applicationRound->scheduled_date->toTimeString()}}">
+                                                                @endif
+                                                            </div>
+                                                            <div class="form-group col-md-4">
+                                                                <label for="expected_time"
+                                                                    class="fz-14 leading-none text-secondary w-100p">
+                                                                    <div>
+                                                                        <span>Expected End Time</span>
+                                                                    </div>
+                                                                </label>
+                                                                @if ($applicationRound->scheduled_date)
+                                                                    <input type="Time" readonly="readonly" name="scheduled_time"
+                                                                        id="scheduled_time"
+                                                                        class="form-control form-control-sm"
+                                                                        value="{{ $applicationRound->scheduled_date->toTimeString()}}">
                                                                 @endif
                                                             </div>
                                                             <div class="form-group col-md-4">
@@ -867,6 +951,20 @@
                                                     {{ $applicationRound->conducted_date->format(config('constants.display_date_format')) }}</span>
                                             @endif
                                         </div>
+                                         @if ($applicationRound->scheduled_date)
+                                                @if ($applicationRound->hangout_link)
+                                                    @if($applicationRound->meeting_duration!= NULL)
+                                                        <input type="Text" readonly="readonly" name="meeting_time"
+                                                        id="meeting_time"
+                                                        class="form-control form-control-sm"
+                                                        value="{{"$applicationRound->meeting_duration"}}">
+                                                        @else
+                                                        <button type="button" id="meet_time" value="{{$applicationRound->id}}" class="py-1 mb-0 btn btn-info btn-sm round-submit finish_interview ">Finish Interview</button>
+                                                        <input type="Text" style="display: none;" readonly="readonly" name="meeting_time"
+                                                        id="meeting_time" class="form-control form-control-sm" value="{{"$applicationRound->meeting_duration"}}">
+                                                  @endif
+                                                @endif
+                                            @endif
                                         <div class="icon-pencil position-relative ml-3 c-pointer" data-toggle="collapse"
                                             data-target="#collapse_{{ $loop->iteration }}"><i class="fa fa-pencil"></i>
                                         </div>
@@ -1083,7 +1181,7 @@
                                                 @if (!$applicationRound->round_status)
                                                     <div class="form-row">
                                                         @if ($application->latestApplicationRound->round->name != "Telephonic Interview"  && $applicationRound->round->name != "Team Interaction Round")
-                                                            <div class="form-group col-md-5">
+                                                            <div class="form-group col-md-4">
                                                                 <label for="scheduled_date"
                                                                     class="fz-14 leading-none text-secondary w-100p">
                                                                     <div>
@@ -1103,16 +1201,50 @@
                                                                     </div>
                                                                 </label>
                                                                 @if ($applicationRound->scheduled_date)
-                                                                    <input type="datetime-local" name="scheduled_date"
+                                                                    <input type="date" name="scheduled_date"
                                                                         id="scheduled_date"
                                                                         class="form-control form-control-sm"
-                                                                        value="{{ $applicationRound->scheduled_date->format(config('constants.display_datetime_format')) }}">
+                                                                        value="{{ $applicationRound->scheduled_date->format(config('constants.date_format')) }}">
                                                                 @else
                                                                 @if($applicationRound->round->name != "Team Interaction Round")
                                                                     <div class="fz-16 leading-tight">Pending calendar confirmation</div>
                                                                 @endif
                                                                 @endif
                                                             </div>
+                                                        <div class="form-group col-md-4">
+                                                            <label for="scheduled_time"
+                                                                class="fz-14 leading-none text-secondary w-100p">
+                                                                <div>
+                                                                    <span>Scheduled Time</span>
+                                                                </div>
+                                                            </label>
+                                                            @if ($applicationRound->scheduled_date)
+                                                                <input type="Time" name="scheduled_time"
+                                                                    id="scheduled_time"
+                                                                    class="form-control form-control-sm"
+                                                                    value="{{ $applicationRound->scheduled_date->toTimeString()}}">
+                                                            @endif
+                                                        </div>
+                                                        <div class="form-group col-md-4">
+                                                            <label for="expected_time"
+                                                                class="fz-14 leading-none text-secondary w-100p">
+                                                                <div>
+                                                                    <span>Expected End Time</span>
+                                                                </div>
+                                                            </label>
+                                                            @if ($applicationRound->scheduled_date)
+                                                            @php
+                                                                $date1 = new DateTime($applicationRound->scheduled_date);
+                                                                $date2 = new DateTime($applicationRound->scheduled_end);
+                                                                $time_diff = $date2->diff($date1);
+                                                                $time=($time_diff->days * 24) + $time_diff->h;
+                                                            @endphp
+                                                                <input type="Text" readonly="readonly" name="expected_time"
+                                                                    id="expected_time"
+                                                                    class="form-control form-control-sm"
+                                                                    value="{{"$time hours"}}">
+                                                            @endif
+                                                        </div>
                                                             <div class="form-group col-md-4">
                                                                 <label for="scheduled_person_id"
                                                                     class="fz-14 leading-none text-secondary">


### PR DESCRIPTION
#2155 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->

<!--- Please complete the following steps and check these boxes before filing your PR: -->

### Description
1.Modified HR/Recruitment/Job/edit page
2.Split scheduled date to date and time from timestamp.
3.Created a migration ,added a "meeting duration" field in "hr_application_round" table that is holding a timestamp for the interview duration.
4.For rounds only where we need calendar events, provided a Finish Interview button left to the pencil icon, clicking on which, an ajax call is going in the backend and saving the interview time in the column created in first step. Interview time is the difference between, scheduled_date timestamp and the time when Finish Interview button is calculated.
5.Fetching the same to the frontend in place of "finish interview button"

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
