### PR TITLE
HotFix: Interest on FD is not showing up on the P&L report 

### DIFF
--- a/Modules/Report/Config/config.php
+++ b/Modules/Report/Config/config.php
@@ -45,7 +45,7 @@ return [
                         'head' => 'Indirect income'
                     ],
 
-                    'interest_on_fd' => [
+                    'interest_on_f_d' => [
                         'name' => 'Interest on FD',
                         'head' => 'Indirect income'
                     ],


### PR DESCRIPTION
We had some inconsistency in a config key and name. I have fixed it. 