### PR TITLE
When the user is an administrator, invoices can be deleted

### DIFF
--- a/Modules/Invoice/Http/Controllers/InvoiceController.php
+++ b/Modules/Invoice/Http/Controllers/InvoiceController.php
@@ -2,12 +2,12 @@
 
 namespace Modules\Invoice\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
-use Modules\Invoice\Entities\Invoice;
 use Modules\Invoice\Contracts\InvoiceServiceContract;
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Modules\Invoice\Entities\Invoice;
 
 class InvoiceController extends Controller
 {
@@ -55,7 +55,7 @@ class InvoiceController extends Controller
     {
         $this->authorize('invoiceDetails', Invoice::class);
         $filters = $request->all();
-        if (! $filters) {
+        if (!$filters) {
             return redirect(route('invoice.details', $this->service->defaultGstReportFilters()));
         }
 
@@ -90,7 +90,7 @@ class InvoiceController extends Controller
             'sent_on' => today(config('constants.timezone.indian')),
             'due_on' => today(config('constants.timezone.indian'))->addDays(6),
             'period_start_date' => $request->period_start_date,
-            'period_end_date' => $request->period_end_date
+            'period_end_date' => $request->period_end_date,
         ]);
         $invoiceNumber = $data['invoiceNumber'];
         $pdf = $this->showInvoicePdf($data);
@@ -141,7 +141,7 @@ class InvoiceController extends Controller
 
     /**
      * Remove the specified resource from storage.
-     * @param int $id
+     * @param Invoice $invoice
      */
     public function destroy(Invoice $invoice)
     {
@@ -162,7 +162,7 @@ class InvoiceController extends Controller
     {
         $this->authorize('taxReport', Invoice::class);
         $filters = $request->all();
-        if (! $filters) {
+        if (!$filters) {
             return redirect(route('invoice.tax-report', $this->service->defaultTaxReportFilters()));
         }
 

--- a/Modules/Invoice/Http/Controllers/InvoiceController.php
+++ b/Modules/Invoice/Http/Controllers/InvoiceController.php
@@ -143,9 +143,9 @@ class InvoiceController extends Controller
      * Remove the specified resource from storage.
      * @param int $id
      */
-    public function destroy($id)
+    public function destroy(Invoice $invoice)
     {
-        return $this->service->delete($id);
+        return $this->service->delete($invoice);
     }
 
     public function getInvoiceFile(Request $request, $invoiceID)

--- a/Modules/Invoice/Http/Controllers/InvoiceController.php
+++ b/Modules/Invoice/Http/Controllers/InvoiceController.php
@@ -2,12 +2,12 @@
 
 namespace Modules\Invoice\Http\Controllers;
 
-use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
-use Modules\Invoice\Contracts\InvoiceServiceContract;
 use Modules\Invoice\Entities\Invoice;
+use Modules\Invoice\Contracts\InvoiceServiceContract;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class InvoiceController extends Controller
 {
@@ -55,7 +55,7 @@ class InvoiceController extends Controller
     {
         $this->authorize('invoiceDetails', Invoice::class);
         $filters = $request->all();
-        if (!$filters) {
+        if (! $filters) {
             return redirect(route('invoice.details', $this->service->defaultGstReportFilters()));
         }
 
@@ -90,7 +90,7 @@ class InvoiceController extends Controller
             'sent_on' => today(config('constants.timezone.indian')),
             'due_on' => today(config('constants.timezone.indian'))->addDays(6),
             'period_start_date' => $request->period_start_date,
-            'period_end_date' => $request->period_end_date,
+            'period_end_date' => $request->period_end_date
         ]);
         $invoiceNumber = $data['invoiceNumber'];
         $pdf = $this->showInvoicePdf($data);
@@ -162,7 +162,7 @@ class InvoiceController extends Controller
     {
         $this->authorize('taxReport', Invoice::class);
         $filters = $request->all();
-        if (!$filters) {
+        if (! $filters) {
             return redirect(route('invoice.tax-report', $this->service->defaultTaxReportFilters()));
         }
 

--- a/Modules/Invoice/Routes/web.php
+++ b/Modules/Invoice/Routes/web.php
@@ -23,7 +23,7 @@ Route::prefix('invoice')->middleware('auth')->group(function () {
     Route::post('/', 'InvoiceController@store')->name('invoice.store');
     Route::get('/{invoice}/edit', 'InvoiceController@edit')->name('invoice.edit');
     Route::post('/{invoice}/update', 'InvoiceController@update')->name('invoice.update');
-    Route::delete('/{invoiceId}/delete', 'InvoiceController@destroy')->name('invoice.delete');
+    Route::delete('/{invoice}/delete', 'InvoiceController@destroy')->name('invoice.delete');
     Route::post('/generate-invoice', 'InvoiceController@generateInvoice')->name('invoice.generate-invoice');
     Route::post('/reminder', 'InvoiceController@sendReminderEmail')->name('invoice.reminder.email');
     Route::post('/payment-received', 'InvoiceController@sendReminderEmail')->name('invoice.payment-received.email');

--- a/Modules/Invoice/Routes/web.php
+++ b/Modules/Invoice/Routes/web.php
@@ -23,7 +23,7 @@ Route::prefix('invoice')->middleware('auth')->group(function () {
     Route::post('/', 'InvoiceController@store')->name('invoice.store');
     Route::get('/{invoice}/edit', 'InvoiceController@edit')->name('invoice.edit');
     Route::post('/{invoice}/update', 'InvoiceController@update')->name('invoice.update');
-    Route::delete('/{invoice}/delete', 'InvoiceController@destroy')->name('invoice.delete');
+    Route::delete('/{invoiceId}/delete', 'InvoiceController@destroy')->name('invoice.delete');
     Route::post('/generate-invoice', 'InvoiceController@generateInvoice')->name('invoice.generate-invoice');
     Route::post('/reminder', 'InvoiceController@sendReminderEmail')->name('invoice.reminder.email');
     Route::post('/payment-received', 'InvoiceController@sendReminderEmail')->name('invoice.payment-received.email');

--- a/Modules/Invoice/Services/InvoiceService.php
+++ b/Modules/Invoice/Services/InvoiceService.php
@@ -228,7 +228,7 @@ class InvoiceService implements InvoiceServiceContract
         ];
     }
 
-    public function delete($invoice)
+    public function delete(Invoice $invoice)
     {
         return $invoice->delete();
     }

--- a/Modules/Invoice/Services/InvoiceService.php
+++ b/Modules/Invoice/Services/InvoiceService.php
@@ -228,9 +228,9 @@ class InvoiceService implements InvoiceServiceContract
         ];
     }
 
-    public function delete($invoiceId)
+    public function delete($invoice)
     {
-        return $invoiceId->delete();
+        return $invoice->delete();
     }
 
     public function getUnpaidInvoices()

--- a/Modules/Invoice/Services/InvoiceService.php
+++ b/Modules/Invoice/Services/InvoiceService.php
@@ -228,9 +228,9 @@ class InvoiceService implements InvoiceServiceContract
         ];
     }
 
-    public function delete($invoiceID)
+    public function delete($invoice)
     {
-        return Invoice::find($invoiceID)->delete();
+        return $invoice->delete();
     }
 
     public function getUnpaidInvoices()

--- a/Modules/Invoice/Services/InvoiceService.php
+++ b/Modules/Invoice/Services/InvoiceService.php
@@ -228,9 +228,9 @@ class InvoiceService implements InvoiceServiceContract
         ];
     }
 
-    public function delete($invoice)
+    public function delete($invoiceId)
     {
-        return $invoice->delete();
+        return $invoiceId->delete();
     }
 
     public function getUnpaidInvoices()


### PR DESCRIPTION
Targets #2739  

### Description
-  Invoices can be deleted when a user is designated as an administrator. It should happen by passing the module class in the destroy function of invoiceController.
reference : https://github.com/laravel/framework/issues/22847#issuecomment-521308861

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
