### PR TITLE
Show project details link to all team members

### DIFF
--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -79,8 +79,13 @@
                                 </td>
                             </tr>
                             @foreach ($client->projects as $project)
-                                 <tr>
-                                    @if('projects.update')
+                                <tr>
+                                    @can('projects.update')
+                                        <td class="w-33p">
+                                            <div class="pl-2 pl-xl-3"><a
+                                                    href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
+                                        </td>
+                                    @else
                                         <td class="w-33p">
                                             <div class="pl-2 pl-xl-3">
                                                 @if($client->key_account_manager_id === auth()->user()->id)
@@ -90,14 +95,9 @@
                                                 @else
                                                      <span>{{ $project->name }}</span>
                                                  @endif
-                                            </div     
+                                            </div 
                                         </td>
-                                    @else
-                                        <td class="w-33p">
-                                            <div class="pl-2 pl-xl-3">{{ $project->name }}</div>
-                                        </td>
-                                    
-                                    @endif
+                                    @endcan
                                     <td class="w-20p">
                                         @foreach ($project->getTeamMembers ?: [] as $teamMember)
                                             <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -88,14 +88,15 @@
                                     @else
                                         <td class="w-33p">
                                             <div class="pl-2 pl-xl-3">
-                                                @if($client->key_account_manager_id === auth()->user()->id)
-                                                 <div class="pl-2 pl-xl-3">
-                                                    <a
-                                                   href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div> 
-                                                @else
-                                                     <span>{{ $project->name }}</span>
-                                                 @endif
-                                            </div 
+                                                @php
+                                                    $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
+                                                    @endphp
+                                                    @if(in_array(auth()->user()->id, $team_member_ids))
+                                                        <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
+                                                    @else
+                                                         <div class="pl-2 pl-xl-3"> {{ $project->name }}</div>
+                                                    @endif
+                                            </div>   
                                         </td>
                                     @endcan
                                     <td class="w-20p">

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -80,22 +80,24 @@
                             </tr>
                             @foreach ($client->projects as $project)
                                  <tr>
-                                    @can('projects.update')
+                                    @if('projects.update')
                                         <td class="w-33p">
-                                            <div class="pl-2 pl-xl-3"><a
-                                                    href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
+                                            <div class="pl-2 pl-xl-3">
+                                                @if($client->key_account_manager_id === auth()->user()->id)
+                                                 <div class="pl-2 pl-xl-3">
+                                                    <a
+                                                   href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div> 
+                                                @else
+                                                     <span>{{ $project->name }}</span>
+                                                 @endif
+                                            </div     
                                         </td>
                                     @else
                                         <td class="w-33p">
-                                            @if($client->key_account_manager_id === auth()->user()->id)
-                                                 <div class="pl-2 pl-xl-3"><a
-                                                   href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div> 
-                                            @else
-                                                 <span>{{ $project->name }}</span>
-                                            @endif
+                                            <div class="pl-2 pl-xl-3">{{ $project->name }}</div>
                                         </td>
                                     
-                                    @endcan
+                                    @endif
                                     <td class="w-20p">
                                         @foreach ($project->getTeamMembers ?: [] as $teamMember)
                                             <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -79,31 +79,25 @@
                                 </td>
                             </tr>
                             @foreach ($client->projects as $project)
-                                @foreach ($project->getTeamMembers ?: [] as $teamMember)
-                                {{-- @dd($project->users) --}}
-                                   {{-- @dd($project) --}}
-                                   {{-- @dd($client) --}}
-                                   {{-- @dd($teamMember) --}}
-                                   {{-- @dd(auth()->user()->id) --}}
-                                <tr>
+                                 <tr>
                                     @can('projects.update')
                                         <td class="w-33p">
-                                            <div class="pl-2 pl-xl-3">
-                                                @if($teamMember->team_member_id=== auth()->user()->id)  
-                                                    <a 
-                                                      href="{{ route('project.show', $project) }}">{{ $project->name }}
-                                                    </a>
-                                                @else
-                                                    <span>{{ $project->name }}</span>
-                                                 @endif -
-                                            </div>
+                                            <div class="pl-2 pl-xl-3"><a
+                                                    href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
                                         </td>
                                     @else
                                         <td class="w-33p">
-                                            <div class="pl-2 pl-xl-3">{{ $project->name }}</div>
+                                            @if($client->key_account_manager_id === auth()->user()->id)
+                                                 <div class="pl-2 pl-xl-3"><a
+                                                   href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div> 
+                                            @else
+                                                 <span>{{ $project->name }}</span>
+                                            @endif
                                         </td>
+                                    
                                     @endcan
                                     <td class="w-20p">
+                                        @foreach ($project->getTeamMembers ?: [] as $teamMember)
                                             <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
                                                 title="{{ $teamMember->user->name }} - {{ config('project.designation')[$teamMember->designation] }} <br>    Efforts: {{ $teamMember->current_actual_effort }} Hours">
 
@@ -111,7 +105,7 @@
                                                         src="{{ $teamMember->user->avatar }}"
                                                         class="w-35 h-30 rounded-circle mb-1 mr-0.5 {{ $teamMember->border_color_class }} border-2"></a>
                                             </span>
-                                        
+                                        @endforeach
                                     </td>
                                     <td class="text-center">
                                         @if (empty($project->projectContracts->first()->contract_file_path))
@@ -129,7 +123,6 @@
                                             class="{{ $textColor }} font-weight-bold">{{ $project->velocity . ' (' . $project->current_hours_for_month . ' Hrs.)' }}</span>
                                     </td>
                                 </tr>
-                                @endforeach
                             @endforeach
                         @empty
                             <tr>

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -79,11 +79,24 @@
                                 </td>
                             </tr>
                             @foreach ($client->projects as $project)
+                                @foreach ($project->getTeamMembers ?: [] as $teamMember)
+                                {{-- @dd($project->users) --}}
+                                   {{-- @dd($project) --}}
+                                   {{-- @dd($client) --}}
+                                   {{-- @dd($teamMember) --}}
+                                   {{-- @dd(auth()->user()->id) --}}
                                 <tr>
                                     @can('projects.update')
                                         <td class="w-33p">
-                                            <div class="pl-2 pl-xl-3"><a
-                                                    href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
+                                            <div class="pl-2 pl-xl-3">
+                                                @if($teamMember->team_member_id=== auth()->user()->id)  
+                                                    <a 
+                                                      href="{{ route('project.show', $project) }}">{{ $project->name }}
+                                                    </a>
+                                                @else
+                                                    <span>{{ $project->name }}</span>
+                                                 @endif -
+                                            </div>
                                         </td>
                                     @else
                                         <td class="w-33p">
@@ -91,7 +104,6 @@
                                         </td>
                                     @endcan
                                     <td class="w-20p">
-                                        @foreach ($project->getTeamMembers ?: [] as $teamMember)
                                             <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
                                                 title="{{ $teamMember->user->name }} - {{ config('project.designation')[$teamMember->designation] }} <br>    Efforts: {{ $teamMember->current_actual_effort }} Hours">
 
@@ -99,7 +111,7 @@
                                                         src="{{ $teamMember->user->avatar }}"
                                                         class="w-35 h-30 rounded-circle mb-1 mr-0.5 {{ $teamMember->border_color_class }} border-2"></a>
                                             </span>
-                                        @endforeach
+                                        
                                     </td>
                                     <td class="text-center">
                                         @if (empty($project->projectContracts->first()->contract_file_path))
@@ -117,6 +129,7 @@
                                             class="{{ $textColor }} font-weight-bold">{{ $project->velocity . ' (' . $project->current_hours_for_month . ' Hrs.)' }}</span>
                                     </td>
                                 </tr>
+                                @endforeach
                             @endforeach
                         @empty
                             <tr>

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -83,19 +83,19 @@
                                     @can('projects.update')
                                         <td class="w-33p">
                                             <div class="pl-2 pl-xl-3"><a
-                                                    href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
+                                                href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
                                         </td>
                                     @else
                                         <td class="w-33p">
                                             <div class="pl-2 pl-xl-3">
                                                 @php
                                                     $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
-                                                    @endphp
-                                                    @if(in_array(auth()->user()->id, $team_member_ids))
-                                                        <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
-                                                    @else
-                                                         <div class="pl-2 pl-xl-3"> {{ $project->name }}</div>
-                                                    @endif
+                                                @endphp
+                                                @if(in_array(auth()->user()->id, $team_member_ids))
+                                                    <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
+                                                @else
+                                                    <div class="pl-2 pl-xl-3"> {{ $project->name }}</div>
+                                                @endif
                                             </div>   
                                         </td>
                                     @endcan
@@ -103,7 +103,6 @@
                                         @foreach ($project->getTeamMembers ?: [] as $teamMember)
                                             <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
                                                 title="{{ $teamMember->user->name }} - {{ config('project.designation')[$teamMember->designation] }} <br>    Efforts: {{ $teamMember->current_actual_effort }} Hours">
-
                                                 <a href={{ route('employees.show', $teamMember->user->employee) }}><img
                                                         src="{{ $teamMember->user->avatar }}"
                                                         class="w-35 h-30 rounded-circle mb-1 mr-0.5 {{ $teamMember->border_color_class }} border-2"></a>


### PR DESCRIPTION
Targets #2678


### Description
Previously , the project link was shown for all members either he/she is member of project or not and I have to fixed this , so that the link is shown only on projects where the user is a team member of the project. I create a check for this.

### Checklist:

- [x] I have performed a self-review of my own code.
