### PR TITLE
 bugfix/incorrect FTE calculation where billing date starts in between of month

### DIFF
--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,19 +47,21 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute()
     {
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $this->project->client->month_start_date)->sum('actual_effort');
+        $firstDayOfMonth = date('y-m-01');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=',$firstDayOfMonth)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute()
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
+        $firstDayOfMonth = date('y-m-01');
 
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();
         }
 
-        $daysTillToday = count($project->getWorkingDaysList($this->project->client->month_start_date, $currentDate));
+        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth,$currentDate));
 
         return $this->daily_expected_effort * $daysTillToday;
     }
@@ -81,12 +83,13 @@ class ProjectTeamMember extends Model
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
+        $firstDayOfMonth = date('y-m-01');
 
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();
         }
 
-        $daysTillToday = count($project->getWorkingDaysList($this->project->client->month_start_date, $currentDate));
+        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth,$currentDate));
         if ($daysTillToday == 0) {
             return 0;
         }

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -45,31 +45,32 @@ class ProjectTeamMember extends Model
         return $query->whereNull('ended_on');
     }
 
-    public function getCurrentActualEffortAttribute()
+    public function getCurrentActualEffortAttribute($startDate = null)
     {
-        $firstDayOfMonth = date('y-m-01');
+        $startDate = $startDate ?? $this->project->client->month_start_date;
 
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $firstDayOfMonth)->sum('actual_effort');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $this->project->client->month_start_date)->sum('actual_effort');
     }
 
-    public function getCurrentExpectedEffortAttribute()
+    public function getCurrentExpectedEffortAttribute($startDate = null)
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
-        $firstDayOfMonth = date('y-m-01');
+        $startDate = $startDate ?? $this->project->client->month_start_date;
 
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();
         }
 
-        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth, $currentDate));
+        $daysTillToday = count($project->getWorkingDaysList($this->project->client->month_start_date, $currentDate));
 
         return $this->daily_expected_effort * $daysTillToday;
     }
 
-    public function getExpectedEffortTillTodayAttribute()
+    public function getExpectedEffortTillTodayAttribute($startDate = null)
     {
         $project = new Project;
+        $startDate = $startDate ?? $this->project->client->month_start_date;
         $daysTillToday = count($project->getWorkingDaysList($this->project->client->month_start_date, today(config('constants.timezone.indian'))));
 
         return $this->daily_expected_effort * $daysTillToday;
@@ -84,7 +85,7 @@ class ProjectTeamMember extends Model
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
-        $firstDayOfMonth = date('y-m-01');
+        $firstDayOfMonth = $this->current_actual_effort;
 
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -49,7 +49,7 @@ class ProjectTeamMember extends Model
     {
         $daysTillToday = date('y-m-01');
 
-        $startDate = $startDate ? $this->project->client->month_start_date :$daysTillToday;
+        $startDate = $startDate ? $this->project->client->month_start_date : $daysTillToday;
 
         return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
     }

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,11 +47,10 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute($startDate = null)
     {
-        $firstDayOfMonth = date('y-m-01');
 
-        $startedDate = $startDate ? $this->project->client->month_start_date : $firstDayOfMonth;
+        $startDate = $startDate ?? $this->project->client->month_start_date ;
 
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startedDate)->sum('actual_effort');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute($startDate = null)

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -48,6 +48,7 @@ class ProjectTeamMember extends Model
     public function getCurrentActualEffortAttribute()
     {
         $firstDayOfMonth = date('y-m-01');
+
         return $this->projectTeamMemberEffort()->where('added_on', '>=', $firstDayOfMonth)->sum('actual_effort');
     }
 

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -48,7 +48,7 @@ class ProjectTeamMember extends Model
     public function getCurrentActualEffortAttribute()
     {
         $firstDayOfMonth = date('y-m-01');
-        return $this->projectTeamMemberEffort()->where('added_on', '>=',$firstDayOfMonth)->sum('actual_effort');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $firstDayOfMonth)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute()
@@ -61,7 +61,7 @@ class ProjectTeamMember extends Model
             $currentDate = $currentDate->subDay();
         }
 
-        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth,$currentDate));
+        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth, $currentDate));
 
         return $this->daily_expected_effort * $daysTillToday;
     }
@@ -89,7 +89,7 @@ class ProjectTeamMember extends Model
             $currentDate = $currentDate->subDay();
         }
 
-        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth,$currentDate));
+        $daysTillToday = count($project->getWorkingDaysList($firstDayOfMonth, $currentDate));
         if ($daysTillToday == 0) {
             return 0;
         }

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,8 +47,7 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute($startDate = null)
     {
-
-        $startDate = $startDate ?? $this->project->client->month_start_date ;
+        $startDate = $startDate ?? $this->project->client->month_start_date;
 
         return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
     }

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,11 +47,11 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute($startDate = null)
     {
-        $daysTillToday = date('y-m-01');
+        $firstDayOfMonth = date('y-m-01');
 
-        $startDate = $startDate ? $this->project->client->month_start_date : $daysTillToday;
+        $startedDate = $startDate ? $this->project->client->month_start_date : $firstDayOfMonth;
 
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startedDate)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute($startDate = null)
@@ -87,7 +87,7 @@ class ProjectTeamMember extends Model
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
-        $firstDayOfMonth = $this->current_actual_effort;
+        $firstDayOfMonth = date('Y-m-01');
 
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,9 +47,10 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute($startDate = null)
     {
-        $startDate = $startDate ?? $this->project->client->month_start_date;
-
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $this->project->client->month_start_date)->sum('actual_effort');
+        $daysTillToday = date('y-m-01');
+        $startDate = $startDate ? $this->project->client->month_start_date :$daysTillToday;
+        
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute($startDate = null)
@@ -96,7 +97,7 @@ class ProjectTeamMember extends Model
             return 0;
         }
 
-        return round($firstDayOfMonth / ($daysTillToday * config('efforttracking.minimum_expected_hours')), 2);
+        return round($this->getCurrentActualEffortAttribute($firstDayOfMonth) / ($daysTillToday * config('efforttracking.minimum_expected_hours')), 2);
     }
 
     public function getBorderColorClassAttribute()

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -48,8 +48,9 @@ class ProjectTeamMember extends Model
     public function getCurrentActualEffortAttribute($startDate = null)
     {
         $daysTillToday = date('y-m-01');
+
         $startDate = $startDate ? $this->project->client->month_start_date :$daysTillToday;
-        
+
         return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
     }
 

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -96,7 +96,7 @@ class ProjectTeamMember extends Model
             return 0;
         }
 
-        return round($this->current_actual_effort / ($daysTillToday * config('efforttracking.minimum_expected_hours')), 2);
+        return round($firstDayOfMonth / ($daysTillToday * config('efforttracking.minimum_expected_hours')), 2);
     }
 
     public function getBorderColorClassAttribute()


### PR DESCRIPTION
Targets #2690 

Description:

I have correct the FTE calculation of the user if the project billing date lies in between the month. 
To do so I have created new variable($firstDayOfMonth) whose value is 2022/01/01 and declared that variable in the FTE calculation function so that in variable $daysTillToday  , workingDaysList() can pass the value of  $firstDayOfMonth and be able to return the desired dates of the working days.

For the hours booked there is a CurrentActualEffort() who returns to the projectTeamMemberEffort() where 'added on' ,'>=',month_start_date ->sum('actual effort'). Here, month_start_date represents project billing date and I have replaced it with $firstDayOfMonth so that FTE calculation should not depend on the project billing date. Therefore, it will sum the actual effort from day 1st to the current date from the database table name "project_team_member_effort". 


The changes are required because the calculation of FTE is from the month start date to the month end date. 
This PR resolves the behavior of the FTE when project billing date lies in between of the month  as the FTE value is now constant when you add any random numbers till the current date of that project. 

 Checklist:

- [x] I have performed a self-review of my own code.
