### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,8 +16,6 @@ jobs:
           php-version: '8.2'
       - name: Install composer dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: Install NPM Dependencies
-        run: npm install
       - name: PHP Coding Standards
         run: PHP_CS_FIXER_IGNORE_ENV=1 php ./vendor/bin/php-cs-fixer fix --config .php-cs-fixer.php --dry-run --verbose --diff
 
@@ -48,8 +46,6 @@ jobs:
           php-version: '8.2'
       - name: Install composer dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: Install NPM Dependencies
-        run: npm install
       - name: Setup env file
         run: cp .env.example .env
       - name: Configure application encryption key

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Compile assets
         run: |
+          export NODE_OPTIONS=--openssl-legacy-provider
           npm install
           npm run dev
 


### PR DESCRIPTION
### Description
1. Added legacy OpenSSL provider option before running npm command as the latest versions of node17 have switched to using OpenSSL3.0
2. The export option is based on this [StackOverflow answer](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported)
3. Removed npm installation from Larastan and PHPCS as these are purely PHP level checks and we don't need node modules. So we can save time when running these jobs.
<!--- Describe your changes in detail -->
<!--- Why these changes are required? What existing problem does the pull request solve? -->

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
