### PR TITLE
bugfix/#2874/Correct-project-name-is-removed-from-the-list

### DIFF
--- a/Modules/Client/Resources/views/subviews/create-client-projects-modal.blade.php
+++ b/Modules/Client/Resources/views/subviews/create-client-projects-modal.blade.php
@@ -1,4 +1,4 @@
-<div class="modal fade" id="exampleModal" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal fade" id="exampleModal{{$project->id}}" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -8,7 +8,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                <form action="{{ route('project.destroy', $project) }}" method="POST" id="delete-form">
+                <form action="{{ route('project.destroy', $project->id) }}" method="POST" id="delete-form">
                     @csrf
                     @method('DELETE')
                     <div class="form-group">

--- a/Modules/Client/Resources/views/subviews/edit-client-projects.blade.php
+++ b/Modules/Client/Resources/views/subviews/edit-client-projects.blade.php
@@ -35,7 +35,7 @@
                     </div>
                         <div class="w-10p mr-10">
                             @include('client::subviews.create-client-projects-modal')
-                            <button type="submit" class="btn btn-danger" data-toggle="modal" data-target="#exampleModal">Remove</button>
+                            <button type="submit" class="btn btn-danger" data-toggle="modal" data-target="#exampleModal{{$project->id}}">Remove</button>
                         </div>
                     </div>
                 @endforeach

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -79,11 +79,9 @@ class ProjectController extends Controller
         ]);
     }
     public function destroy(ProjectRequest $request, Project $project)
-    
-    { 
+    {
         $project->update(
-            
-            [ 
+            [
                 'reason_for_deletion' => $request['comment']
             ]
         );

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -79,14 +79,13 @@ class ProjectController extends Controller
         ]);
     }
 
-    public function destroy(ProjectRequest $request, $id)
-    {
-        Project::updateOrCreate(
-            [
+    public function destroy(ProjectRequest $request, Project $project)
+    { 
+        $project->update(
+            [ 
                 'reason_for_deletion' => $request['comment']
             ]
         );
-        $project = project::find($id);
         $project->delete();
 
         return redirect()->back()->with('status', 'Project deleted successfully!');

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -79,8 +79,10 @@ class ProjectController extends Controller
         ]);
     }
     public function destroy(ProjectRequest $request, Project $project)
+    
     { 
         $project->update(
+            
             [ 
                 'reason_for_deletion' => $request['comment']
             ]

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -78,12 +78,10 @@ class ProjectController extends Controller
             'daysTillToday' => $daysTillToday,
         ]);
     }
-
-    public function destroy(ProjectRequest $request, Project $project)
     
+    public function destroy(ProjectRequest $request, Project $project)
     { 
         $project->update(
-            
             [ 
                 'reason_for_deletion' => $request['comment']
             ]

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -78,13 +78,14 @@ class ProjectController extends Controller
         ]);
     }
 
-    public function destroy(ProjectRequest $request, Project $project)
+    public function destroy(ProjectRequest $request, $id)
     {
         Project::updateOrCreate(
             [
                 'reason_for_deletion' => $request['comment']
             ]
         );
+        $project=project::find($id);
         $project->delete();
 
         return redirect()->back()->with('status', 'Project deleted successfully!');

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -80,8 +80,10 @@ class ProjectController extends Controller
     }
 
     public function destroy(ProjectRequest $request, Project $project)
+    
     { 
         $project->update(
+            
             [ 
                 'reason_for_deletion' => $request['comment']
             ]

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -78,7 +78,6 @@ class ProjectController extends Controller
             'daysTillToday' => $daysTillToday,
         ]);
     }
-    
     public function destroy(ProjectRequest $request, Project $project)
     { 
         $project->update(

--- a/Modules/Project/Http/Controllers/ProjectController.php
+++ b/Modules/Project/Http/Controllers/ProjectController.php
@@ -86,7 +86,7 @@ class ProjectController extends Controller
                 'reason_for_deletion' => $request['comment']
             ]
         );
-        $project=project::find($id);
+        $project = project::find($id);
         $project->delete();
 
         return redirect()->back()->with('status', 'Project deleted successfully!');

--- a/Modules/Project/Routes/web.php
+++ b/Modules/Project/Routes/web.php
@@ -19,6 +19,6 @@ Route::prefix('projects')->middleware('auth')->group(function () {
     Route::post('/', 'ProjectController@store')->name('project.store');
     Route::post('/{project}/update', 'ProjectController@update')->name('project.update');
     Route::get('/contract/pdf/{contract}', 'ProjectController@showPdf')->name('pdf.show');
-    Route::delete('client/{project}/edit', 'ProjectController@destroy')->name('project.destroy');
+    Route::delete('client/{id}/edit', 'ProjectController@destroy')->name('project.destroy');
     //Route::get('/', 'ProjectController@edit')->name('project.edit');
 });

--- a/Modules/Project/Routes/web.php
+++ b/Modules/Project/Routes/web.php
@@ -19,6 +19,7 @@ Route::prefix('projects')->middleware('auth')->group(function () {
     Route::post('/', 'ProjectController@store')->name('project.store');
     Route::post('/{project}/update', 'ProjectController@update')->name('project.update');
     Route::get('/contract/pdf/{contract}', 'ProjectController@showPdf')->name('pdf.show');
-    Route::delete('client/{id}/edit', 'ProjectController@destroy')->name('project.destroy');
+    Route::delete('client/{project}/edit', 'ProjectController@destroy')->name('project.destroy');
+    Route::get('/project-fte-export', 'ProjectController@projectFTEExport')->name('project.fte.export');
     //Route::get('/', 'ProjectController@edit')->name('project.edit');
 });


### PR DESCRIPTION
Targets #2874 

### Description
There is an issue in edit client information ,whenever in projects where the first project name in the sequence is always being removed even if we are trying to remove a project name other than the first one. This issue is related to the project id the correct id is not passes from the remove button. 

### Checklist:
- [x] I have performed a self-review of my own code.
