### PR TITLE
feature/2878/add-icon-to-display-additional-team-members-required

### DIFF
--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -97,10 +97,17 @@
                             @foreach ($client->projects as $project)
                                 <tr>
                                     @can('projects.update')
-                                        <td class="w-33p">
-                                            <div class="pl-2 pl-xl-3"><a
-                                                    href="{{ route('project.show', $project) }}">{{ $project->name }}</a></div>
-                                        </td>
+                                    <td class="w-33p">
+                                        <div class="pl-2 pl-xl-3">
+                                          @if ($project->getTotalToBeDeployedCount() > 0)
+                                            <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
+                                                  title="There is a requirement for {{ $project->getTotalToBeDeployedCount() }} team members">
+                                              <i class="fa fa-users text-danger mr-0.5" aria-hidden="true"></i>
+                                            </span>
+                                          @endif
+                                          <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
+                                        </div>
+                                      </td>
                                     @else
                                         <td class="w-33p">
                                             <div class="pl-2 pl-xl-3">


### PR DESCRIPTION
Targets #2878

 Description:

- Added an icon, which displays additional team members required in a project and on hovering it shows "There is a requirement for number of team members" in a tooltip.
- Whenever there will be requirement of team members a red icon will be displayed as an alert to the project listing page. 

Checklist:
- [x] I have performed a self-review of my own code.
