### PR TITLE
Show correct velocity of team members according to their added on data in a project

### DIFF
--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -56,15 +56,16 @@ class ProjectTeamMember extends Model
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
-        $startDate = $startDate ?? $this->project->client->month_start_date;
+        if ($this->started_on && $this->started_on > $startDate) {
+            $startDate = $this->started_on;
+        } else {
+            $startDate = $this->project->client->month_start_date;
+        }
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();
         }
 
-        $daysTillToday = count($project->getWorkingDaysList($this->project->client->month_start_date, $currentDate));
-        if ($this->started_on && $this->started_on > $startDate) {
-            $daysTillToday = count($project->getWorkingDaysList($this->started_on, $currentDate));
-        }
+        $daysTillToday = count($project->getWorkingDaysList($startDate, $currentDate));
 
         return $this->daily_expected_effort * $daysTillToday;
     }

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -56,7 +56,7 @@ class ProjectTeamMember extends Model
     {
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
-        if ($this->started_on && $this->started_on > $startDate) {
+        if ($this->started_on && $this->started_on > $this->project->client->month_start_date) {
             $startDate = $this->started_on;
         } else {
             $startDate = $this->project->client->month_start_date;

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,9 +47,9 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute($startDate = null)
     {
-        $startDate = $startDate ?? $this->project->client->month_start_date;
+        $startDate = $startDate ?? $this->started_on;
 
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $this->started_on)->where('added_on', '>=', $startDate)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute($startDate = null)
@@ -57,12 +57,14 @@ class ProjectTeamMember extends Model
         $project = new Project;
         $currentDate = today(config('constants.timezone.indian'));
         $startDate = $startDate ?? $this->project->client->month_start_date;
-
         if (now(config('constants.timezone.indian'))->format('H:i:s') < config('efforttracking.update_date_count_after_time')) {
             $currentDate = $currentDate->subDay();
         }
 
         $daysTillToday = count($project->getWorkingDaysList($this->project->client->month_start_date, $currentDate));
+        if ($this->started_on && $this->started_on > $startDate) {
+            $daysTillToday = count($project->getWorkingDaysList($this->started_on, $currentDate));
+        }
 
         return $this->daily_expected_effort * $daysTillToday;
     }

--- a/Modules/Project/Entities/ProjectTeamMember.php
+++ b/Modules/Project/Entities/ProjectTeamMember.php
@@ -47,9 +47,9 @@ class ProjectTeamMember extends Model
 
     public function getCurrentActualEffortAttribute($startDate = null)
     {
-        $startDate = $startDate ?? $this->started_on;
+        $startDate = $startDate ?? $this->project->client->month_start_date;
 
-        return $this->projectTeamMemberEffort()->where('added_on', '>=', $this->started_on)->where('added_on', '>=', $startDate)->sum('actual_effort');
+        return $this->projectTeamMemberEffort()->where('added_on', '>=', $startDate)->sum('actual_effort');
     }
 
     public function getCurrentExpectedEffortAttribute($startDate = null)


### PR DESCRIPTION
Targets #2877
### Description
Previously, the velocity of a team members is calculated from the start date of the project billing cycle . This doesn't depends on whether the team members are added in middle of the month or at the end of the month. Due to this the velocity of new members does not come correct in the first month. But now the velocity of  team members is calculated from the started_on date in the project for first month only  if team member team member is added in the middle of the month.

### Checklist:
- [x] I have performed a self-review of my own code.
