### PR TITLE
Automated notification to update the efforts sheet before the end of billing cycle.

### DIFF
--- a/Modules/Project/Console/GoogleChat/NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat.php
+++ b/Modules/Project/Console/GoogleChat/NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat.php
@@ -14,7 +14,7 @@ class NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat extends Command
      *
      * @var string
      */
-    protected $name = 'project:notification-to-update-effort-for-project';
+    protected $name = 'project:reminder-for-effortsheet-lock';
 
     /**
      * The console command description.

--- a/Modules/Project/Console/GoogleChat/NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat.php
+++ b/Modules/Project/Console/GoogleChat/NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat.php
@@ -21,7 +21,7 @@ class NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat extends Command
      *
      * @var string
      */
-    protected $description = 'Sends a simple notification on a Google Chat channel to update their effort.';
+    protected $description = 'Sends a simple notification on a Google Chat channel to update their effort before the end date.';
 
     /**
      * Create a new command instance.

--- a/Modules/Project/Console/GoogleChat/NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat.php
+++ b/Modules/Project/Console/GoogleChat/NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Modules\Project\Console\GoogleChat;
+
+use Illuminate\Console\Command;
+use Modules\Project\Entities\Project;
+use Illuminate\Support\Facades\Notification;
+use Modules\Project\Notifications\GoogleChat\NotificationToUpdateEffortForProject;
+
+class NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'project:notification-to-update-effort-for-project';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sends a simple notification on a Google Chat channel to update their effort.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $projects = Project::with('getTeamMembers')->whereHas('teamMembers')->where('status', 'active')->get();
+        foreach ($projects as $project) {
+            if ($project->google_chat_webhook_url && $project->effort_sheet_url) {
+                Notification::route('googleChat', $project->google_chat_webhook_url)->notify(new NotificationToUpdateEffortForProject($project));
+            }
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -37,26 +37,13 @@ class NotificationToUpdateEffortForProject extends Notification
 
     public function toGoogleChat($notifiable)
     {
-        $projects = PROJECT::all();
+        $projects = Project::all();
         foreach ($projects as $project) {
-            $diff_project = date_diff(($project->end_date), (CARBON::NOW()));
+            $diff_in_dates = date_diff($project->end_date, today());
 
-            if ($diff_project->days == 1) {
+            if ($diff_in_dates->days == 1) {
                 return GoogleChatMessage::create()
-                    ->mentionAll('', " it's time to update your efforts, the end date is tomorrow!\n")
-                    ->card(
-                        Card::create()
-                            ->section(
-                                Section::create(
-                                    KeyValue::create('Project', $this->project->name)
-                                    ->setContentMultiline(true)
-                                    ->icon(Icon::CLOCK)
-                                    ->button(
-                                        TextButton::create($this->project->effort_sheet_url, 'Open effortsheet')
-                                    )
-                                ),
-                            ),
-                    );
+                    ->mentionAll('', "  Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.\n");
             }
         }
     }

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -2,17 +2,11 @@
 
 namespace Modules\Project\Notifications\GoogleChat;
 
-use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
-use NotificationChannels\GoogleChat\Card;
 use Modules\Project\Entities\Project;
 use Illuminate\Notifications\Notification;
-use NotificationChannels\GoogleChat\Section;
-use NotificationChannels\GoogleChat\Enums\Icon;
-use NotificationChannels\GoogleChat\Widgets\KeyValue;
 use NotificationChannels\GoogleChat\GoogleChatChannel;
 use NotificationChannels\GoogleChat\GoogleChatMessage;
-use NotificationChannels\GoogleChat\Components\Button\TextButton;
 
 class NotificationToUpdateEffortForProject extends Notification
 {

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -39,11 +39,11 @@ class NotificationToUpdateEffortForProject extends Notification
     {
         $projects = PROJECT::all();
         foreach ($projects as $project) {
-            $diff_project = CARBON::NOW()->diff($project->end_date());
+            $diff_project = ($project->end_date())->diff(CARBON::NOW());
 
             if ($diff_project == 1) {
                 return GoogleChatMessage::create()
-                    ->mentionAll('', " it's time to update your efforts the end date is tomorrow!\n")
+                    ->mentionAll('', " it's time to update your efforts, the end date is tomorrow!\n")
                     ->card(
                         Card::create()
                             ->section(

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -39,7 +39,7 @@ class NotificationToUpdateEffortForProject extends Notification
     {
         $projects = PROJECT::all();
         foreach ($projects as $project) {
-            $diff_project = ($project->end_date())->diff(CARBON::NOW());
+            $diff_project = ($project->end_date)->diff(CARBON::NOW());
 
             if ($diff_project == 1) {
                 return GoogleChatMessage::create()

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -33,9 +33,9 @@ class NotificationToUpdateEffortForProject extends Notification
     {
         $projects = Project::all();
         foreach ($projects as $project) {
-            $diff_in_dates = date_diff($project->end_date, today());
+            $interval = date_diff($project->end_date, today());
 
-            if ($diff_in_dates->days == 1) {
+            if ($interval->days == 1) {
                 return GoogleChatMessage::create()
                     ->mentionAll('', "  Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.\n");
             }

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Modules\Project\Notifications\GoogleChat;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use NotificationChannels\GoogleChat\Card;
+use Modules\Project\Entities\Project;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\GoogleChat\Section;
+use NotificationChannels\GoogleChat\Enums\Icon;
+use NotificationChannels\GoogleChat\Widgets\KeyValue;
+use NotificationChannels\GoogleChat\GoogleChatChannel;
+use NotificationChannels\GoogleChat\GoogleChatMessage;
+use NotificationChannels\GoogleChat\Components\Button\TextButton;
+
+class NotificationToUpdateEffortForProject extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($project)
+    {
+        $this->project = $project;
+    }
+
+    public function via($notifiable)
+    {
+        return [
+            GoogleChatChannel::class
+        ];
+    }
+
+    public function toGoogleChat($notifiable)
+    {
+        $projects = PROJECT::all();
+        foreach ($projects as $project) {
+            $diff_project = CARBON::NOW()->diff($project->end_date());
+
+            if ($diff_project == 1) {
+                return GoogleChatMessage::create()
+                    ->mentionAll('', " it's time to update your efforts the end date is tomorrow!\n")
+                    ->card(
+                        Card::create()
+                            ->section(
+                                Section::create(
+                                    KeyValue::create('Project', $this->project->name)
+                                    ->setContentMultiline(true)
+                                    ->icon(Icon::CLOCK)
+                                    ->button(
+                                        TextButton::create($this->project->effort_sheet_url, 'Open effortsheet')
+                                    )
+                                ),
+                            ),
+                    );
+            }
+        }
+    }
+}

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -39,9 +39,9 @@ class NotificationToUpdateEffortForProject extends Notification
     {
         $projects = PROJECT::all();
         foreach ($projects as $project) {
-            $diff_project = date_diff(($project->end_date),(CARBON::NOW()));
+            $diff_project = date_diff(($project->end_date), (CARBON::NOW()));
 
-            if ($diff_project === 1) {
+            if ($diff_project->days == 1) {
                 return GoogleChatMessage::create()
                     ->mentionAll('', " it's time to update your efforts, the end date is tomorrow!\n")
                     ->card(

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -39,9 +39,9 @@ class NotificationToUpdateEffortForProject extends Notification
     {
         $projects = PROJECT::all();
         foreach ($projects as $project) {
-            $diff_project = ($project->end_date)->diff(CARBON::NOW());
+            $diff_project = date_diff(($project->end_date),(CARBON::NOW()));
 
-            if ($diff_project == 1) {
+            if ($diff_project === 1) {
                 return GoogleChatMessage::create()
                     ->mentionAll('', " it's time to update your efforts, the end date is tomorrow!\n")
                     ->card(

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,6 +12,7 @@ use Modules\Project\Console\SendEffortSummaryCommand;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Modules\Project\Console\GoogleChat\SendDailyEffortSummaryForProjectsOnGoogleChat;
 use Modules\Project\Console\GoogleChat\RemindProjectMembersToUpdateEffortOnGoogleChat;
+use Modules\Project\Console\GoogleChat\NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat;
 
 class Kernel extends ConsoleKernel
 {
@@ -29,6 +30,7 @@ class Kernel extends ConsoleKernel
         FixedBudgetProject::class,
         SendDailyEffortSummaryForProjectsOnGoogleChat::class,
         RemindProjectMembersToUpdateEffortOnGoogleChat::class,
+        NotificationToProjectTeamMembersToUpdateEffortOnGoogleChat::class,
     ];
 
     /**
@@ -54,6 +56,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('project:remind-to-update-effort')->weekdays()->at('19:00');
         $schedule->command('project:send-daily-effort-summary-google-chat')->weekdays()->at('22:30');
         $schedule->command('project:zero-expected-hours-in-project')->weekly()->tuesdays()->at('11:00');
+        $schedule->command('project:notification-to-update-effort-for-project')->at('21:00');
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -56,7 +56,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('project:remind-to-update-effort')->weekdays()->at('19:00');
         $schedule->command('project:send-daily-effort-summary-google-chat')->weekdays()->at('22:30');
         $schedule->command('project:zero-expected-hours-in-project')->weekly()->tuesdays()->at('11:00');
-        $schedule->command('project:notification-to-update-effort-for-project')->at('21:00');
+        $schedule->command('project:reminder-for-effortsheet-lock')->at('21:00');
     }
 
     /**


### PR DESCRIPTION
Targets #2895 
### Description
Currently, we don't have any automated notification system feature which tells to update the efforts sheet of a project to avoid last minutes updates at the end of the billing cycle.
So, created an automated notification system telling all active project members  to update the efforts sheet to avoid last minutes updates.

### Checklist:
- [X] I have performed a self-review of my own code.
