### PR TITLE
Automated reminder to update the efforts sheet before the end of billing cycle.

### DIFF
--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -3,8 +3,8 @@
 namespace Modules\Project\Notifications\GoogleChat;
 
 use Illuminate\Bus\Queueable;
-use Modules\Project\Entities\Project;
 use Illuminate\Notifications\Notification;
+use Modules\Client\Entities\Client;
 use NotificationChannels\GoogleChat\GoogleChatChannel;
 use NotificationChannels\GoogleChat\GoogleChatMessage;
 
@@ -31,9 +31,9 @@ class NotificationToUpdateEffortForProject extends Notification
 
     public function toGoogleChat($notifiable)
     {
-        $projects = Project::all();
+        $projects = Client::all();
         foreach ($projects as $project) {
-            $interval = date_diff($project->end_date, today());
+            $interval = date_diff($project->billingDetails->billing_date, today());
 
             if ($interval->days == 1) {
                 return GoogleChatMessage::create()


### PR DESCRIPTION
Targets #2895
### Description
Currently, we don't have any automated notification system feature which tells to update the efforts sheet of a project to avoid last minutes updates at the end of the billing cycle.
So, created an automated notification system telling all active project members to update the efforts sheet to avoid last minutes updates.

### Checklist:
- [X] I have performed a self-review of my own code.
