### PR TITLE
Automated notification to update the efforts sheet before billing date.

### DIFF
--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -37,7 +37,6 @@ class NotificationToUpdateEffortForProject extends Notification
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
             if($date > today()) {
                 $interval = date_diff(today(), $date);
-    
                 if ($interval->days == 1) {
                     return GoogleChatMessage::create()
                         ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -36,8 +36,8 @@ class NotificationToUpdateEffortForProject extends Notification
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
             if ($date > today()) {
-                $interval = date_diff(today(), $date);
-                if ($interval->days == 1) {
+                $interval = today()->diffInDays($date);
+                if ($interval == 1) {
                     return GoogleChatMessage::create()
                         ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');
                 }

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -35,8 +35,7 @@ class NotificationToUpdateEffortForProject extends Notification
         $projects = Project::all();
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
-            $interval = (strtotime($date) - strtotime(today())) / (60 * 60 * 24);
-            if ($interval == 1) {
+            if (Carbon::tomorrow() == $date) {
                 return GoogleChatMessage::create()
                     ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');
             }

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -35,11 +35,13 @@ class NotificationToUpdateEffortForProject extends Notification
         $projects = Project::all();
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
-            $interval = date_diff($date, today());
-
-            if ($interval->days == 1) {
-                return GoogleChatMessage::create()
-                    ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');
+            if($date > today()) {
+                $interval = date_diff(today(), $date);
+    
+                if ($interval->days == 1) {
+                    return GoogleChatMessage::create()
+                        ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');
+                }
             }
         }
     }

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -35,7 +35,7 @@ class NotificationToUpdateEffortForProject extends Notification
         $projects = Project::all();
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
-            if($date > today()) {
+            if ($date > today()) {
                 $interval = date_diff(today(), $date);
                 if ($interval->days == 1) {
                     return GoogleChatMessage::create()

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -36,7 +36,7 @@ class NotificationToUpdateEffortForProject extends Notification
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
             if ($date > today()) {
-                $interval = Carbon::now()->diffInDays($date);
+                $interval = today()->diffInDays($date);
                 if ($interval == 1) {
                     return GoogleChatMessage::create()
                         ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -35,12 +35,10 @@ class NotificationToUpdateEffortForProject extends Notification
         $projects = Project::all();
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
-            if ($date > today()) {
-                $interval = today()->diffInDays($date);
-                if ($interval == 1) {
-                    return GoogleChatMessage::create()
-                        ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');
-                }
+            $interval = (strtotime($date) - strtotime(today())) / (60 * 60 * 24);
+            if ($interval == 1) {
+                return GoogleChatMessage::create()
+                    ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');
             }
         }
     }

--- a/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
+++ b/Modules/Project/Notifications/GoogleChat/NotificationToUpdateEffortForProject.php
@@ -36,7 +36,7 @@ class NotificationToUpdateEffortForProject extends Notification
         foreach ($projects as $project) {
             $date = Carbon::today()->setDay($project->client->billingDetails->billing_date);
             if ($date > today()) {
-                $interval = today()->diffInDays($date);
+                $interval = Carbon::now()->diffInDays($date);
                 if ($interval == 1) {
                     return GoogleChatMessage::create()
                         ->mentionAll('', ' Please check and update the efforts sheet to avoid last minutes updates at the end of the billing cycle.');


### PR DESCRIPTION
Targets #2895 
### Description
Currently, we don't have any automated notification system feature which tells to update the efforts sheet of a project to avoid last minutes updates at the end of the billing cycle.
So, created an automated notification system telling all active project members to update the efforts sheet to avoid last minutes updates.

### Checklist:
- [X] I have performed a self-review of my own code.
