### PR TITLE
feature/2948/add-authorization-for-code-codeTrek-page

### DIFF
--- a/Modules/CodeTrek/Database/Seeders/CodeTrekPermissionTableSeeder.php
+++ b/Modules/CodeTrek/Database/Seeders/CodeTrekPermissionTableSeeder.php
@@ -41,5 +41,10 @@ class CodeTrekPermissionTableSeeder extends Seeder
         foreach ($applicantPermissions as $permission) {
             $superAdminRole->givePermissionTo($permission['name']);
         }
+        //Give permission to employee role
+        $employeeRole = Role::where(['name' => 'employee'])->first();
+        foreach ($applicantPermissions as $permission) {
+            $employeeRole->givePermissionTo($permission['name']);
+        }
     }
 }

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
@@ -7,13 +7,17 @@ use Illuminate\Http\Request;
 use Modules\CodeTrek\Entities\CodeTrekApplicant;
 use Modules\CodeTrek\Http\Requests\CodeTrekRequest;
 use Modules\CodeTrek\Services\CodeTrekService;
-use Illuminate\Support\Facades\Gate;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class CodeTrekController extends Controller
 {
+    use AuthorizesRequests;
+
     protected $service;
+
     public function __construct(CodeTrekService $service)
     {
+        $this->authorizeResource(CodeTrekApplicant::class);
         $this->service = $service;
     }
     /**
@@ -21,10 +25,6 @@ class CodeTrekController extends Controller
      */
     public function index()
     {
-        if (Gate::denies('codetrek_applicant.view')) {
-            abort(403, 'Unauthorized access');
-        }
-
         return view('codetrek::index', $this->service->getCodeTrekApplicants(request()->all()));
     }
 

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Modules\CodeTrek\Entities\CodeTrekApplicant;
 use Modules\CodeTrek\Http\Requests\CodeTrekRequest;
 use Modules\CodeTrek\Services\CodeTrekService;
+use Illuminate\Support\Facades\Gate;
 
 class CodeTrekController extends Controller
 {
@@ -20,6 +21,10 @@ class CodeTrekController extends Controller
      */
     public function index()
     {
+        if (Gate::denies('codetrek_applicant.view')) {
+            abort(403, 'Unauthorized access');
+        }
+
         return view('codetrek::index', $this->service->getCodeTrekApplicants(request()->all()));
     }
 

--- a/Modules/CodeTrek/Providers/CodeTrekAuthServiceProvider.php
+++ b/Modules/CodeTrek/Providers/CodeTrekAuthServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Modules\CodeTrek\Providers;
 
 use Modules\CodeTrek\Entities\CodeTrekApplicant;

--- a/Modules/CodeTrek/Providers/CodeTrekAuthServiceProvider.php
+++ b/Modules/CodeTrek/Providers/CodeTrekAuthServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+namespace Modules\CodeTrek\Providers;
+
+use Modules\CodeTrek\Entities\CodeTrekApplicant;
+use Modules\CodeTrek\Policies\CodeTrekApplicantPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider;
+
+class CodeTrekAuthServiceProvider extends AuthServiceProvider
+{
+    protected $policies = [
+        CodeTrekApplicant::class => CodeTrekApplicantPolicy::class,
+    ];
+
+    public function boot()
+    {
+        $this->registerPolicies();
+    }
+}

--- a/Modules/CodeTrek/Routes/web.php
+++ b/Modules/CodeTrek/Routes/web.php
@@ -11,7 +11,7 @@
 |
 */
 
-Route::prefix('codetrek')->group(function () {
+Route::prefix('codetrek')->middleware('auth')->group(function () {
     Route::get('/', 'CodeTrekController@index')->name('codetrek.index');
     Route::post('/', 'CodeTrekController@store')->name('codetrek.store');
     Route::get('/edit/{applicant}', 'CodeTrekController@edit')->name('codetrek.edit');


### PR DESCRIPTION
Targets #2948 

### Description

So anyone with role employee, admin and super admin should be able to open CodeTrek page. Currently only admin and super admin has CodeTrek option in the menu
If someone is trying to open the page using link then you have implement Laravel policies like we have in invoice module so that if a user does not have permission CodeTrek.view


### Checklist:
- [x] I have performed a self-review of my own code.
