### PR TITLE
feature/2964/CodeTrek_Applicant_Inactive_Action

### DIFF
--- a/Modules/CodeTrek/Config/config.php
+++ b/Modules/CodeTrek/Config/config.php
@@ -11,6 +11,10 @@ return [
             'label' => 'Inactive',
             'slug'  => 'inactive'
         ],
+        'completed' =>[
+            'label' => 'Completed',
+            'slug'  => 'completed'
+        ],
     ],
     'rounds' =>[
         'level-1' =>[

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
@@ -64,18 +64,31 @@ class CodeTrekApplicantRoundDetailController extends Controller
         return redirect()->back()->with('success', 'Round details updated successfully.');
     }
 
+    // public function updateStatus(Request $request, CodeTrekApplicant $applicant)
+    // {
+    //     if ($request->input('action') === 'inactive') {
+    //         $applicant->status = 'inactive';
+    //     } else {
+    //         $applicant->status = 'completed';
+    //     }
+
+    //     $applicant->save();
+
+    //     return redirect()->route('codetrek.index');
+    // }
     public function updateStatus(Request $request, CodeTrekApplicant $applicant)
     {
-        if ($request->input('action') === 'inactive') {
-            $applicant->status = 'inactive';
+        if ($request->input('action') === config('codetrek.status.inactive.slug')) {
+            $applicant->status = config('codetrek.status.inactive.slug');
         } else {
-            $applicant->status = 'completed';
+            $applicant->status = config('codetrek.status.completed.slug');
         }
 
         $applicant->save();
 
         return redirect()->route('codetrek.index');
     }
+
     /**
      * Remove the specified resource from storage.
      */

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
@@ -4,6 +4,7 @@ namespace Modules\CodeTrek\Http\Controllers;
 
 use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
+use Modules\CodeTrek\Entities\CodeTrekApplicant;
 use Modules\CodeTrek\Services\CodeTrekRoundDetailService;
 use Modules\CodeTrek\Entities\CodeTrekApplicantRoundDetail;
 
@@ -61,6 +62,14 @@ class CodeTrekApplicantRoundDetailController extends Controller
         $this->service->takeAction($request, $id);
 
         return redirect()->back()->with('success', 'Round details updated successfully.');
+    }
+
+    public function markInactive(CodeTrekApplicant $applicant)
+    {
+        $applicant->status = 'inactive';
+        $applicant->save();
+
+        return redirect()->route('codetrek.index');
     }
     /**
      * Remove the specified resource from storage.

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
@@ -64,9 +64,14 @@ class CodeTrekApplicantRoundDetailController extends Controller
         return redirect()->back()->with('success', 'Round details updated successfully.');
     }
 
-    public function markInactive(CodeTrekApplicant $applicant)
+    public function updateStatus(Request $request, CodeTrekApplicant $applicant)
     {
-        $applicant->status = 'inactive';
+        if ($request->input('action') === 'inactive') {
+            $applicant->status = 'inactive';
+        } else {
+            $applicant->status = 'completed';
+        }
+
         $applicant->save();
 
         return redirect()->route('codetrek.index');

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekApplicantRoundDetailController.php
@@ -64,18 +64,6 @@ class CodeTrekApplicantRoundDetailController extends Controller
         return redirect()->back()->with('success', 'Round details updated successfully.');
     }
 
-    // public function updateStatus(Request $request, CodeTrekApplicant $applicant)
-    // {
-    //     if ($request->input('action') === 'inactive') {
-    //         $applicant->status = 'inactive';
-    //     } else {
-    //         $applicant->status = 'completed';
-    //     }
-
-    //     $applicant->save();
-
-    //     return redirect()->route('codetrek.index');
-    // }
     public function updateStatus(Request $request, CodeTrekApplicant $applicant)
     {
         if ($request->input('action') === config('codetrek.status.inactive.slug')) {

--- a/Modules/CodeTrek/Resources/views/evaluate.blade.php
+++ b/Modules/CodeTrek/Resources/views/evaluate.blade.php
@@ -62,23 +62,34 @@
                              </form>
                          </div>
                          @if ($loop->last)
+
                              <form action="{{ route('codetrek.action', $applicant->id) }}" method="POST">
                                  @csrf
                                  <div class="card-footer">
-                                     <select name="round" id="rounds" class="w-22p">
-                                         @foreach (config('codetrek.rounds') as $round)
-                                             <option value="{{ $round['slug'] }}">Move to {{ $round['label'] }}</option>
-                                         @endforeach
-                                     </select>
-                                     <button type="submit" class="btn btn-success">Take Action</button>
-                                     <button type="button" class="btn btn-danger">Marked Inactive</button>
-                                 </div>
+                                     <div class="row align-items-center">
+                                         <select name="round" id="rounds" class="w-22p">
+                                             @foreach (config('codetrek.rounds') as $round)
+                                                 <option value="{{ $round['slug'] }}">Move to {{ $round['label'] }}
+                                                 </option>
+                                             @endforeach
+                                         </select>
+                                         <div class="col-md-auto">
+                                         <button type="submit" class="btn btn-success">Take Action</button>
+                                         </div>
                              </form>
-                         @endif
+                             <div class="md-auto">
+                             <form action="{{ route('codetrek.markInactive', $applicant->id) }}" method="POST">
+                                 @csrf
+                                 <button type="submit" class="btn btn-danger">Marked Inactive</button>
+                             </div>
+                             </form>
                      </div>
                  </div>
-                 <br>
-             </div>
-         </div>
+     @endif
+     </div>
+     </div>
+     <br>
+     </div>
+     </div>
      @endforeach
  @endsection

--- a/Modules/CodeTrek/Resources/views/evaluate.blade.php
+++ b/Modules/CodeTrek/Resources/views/evaluate.blade.php
@@ -62,26 +62,25 @@
                              </form>
                          </div>
                          @if ($loop->last)
-
                              <form action="{{ route('codetrek.action', $applicant->id) }}" method="POST">
                                  @csrf
                                  <div class="card-footer">
-                                     <div class="row align-items-center">
+                                     <div class="d-flex align-items-center">
                                          <select name="round" id="rounds" class="w-22p">
                                              @foreach (config('codetrek.rounds') as $round)
                                                  <option value="{{ $round['slug'] }}">Move to {{ $round['label'] }}
                                                  </option>
                                              @endforeach
                                          </select>
-                                         <div class="col-md-auto">
-                                         <button type="submit" class="btn btn-success">Take Action</button>
-                                         </div>
+                                         <button type="submit" class="btn btn-success ml-2">Take Action</button>
                              </form>
-                             <div class="md-auto">
-                             <form action="{{ route('codetrek.markInactive', $applicant->id) }}" method="POST">
+                             <form action="{{ route('codetrek.updateStatus', $applicant->id) }}" method="POST">
                                  @csrf
-                                 <button type="submit" class="btn btn-danger">Marked Inactive</button>
-                             </div>
+                                 <input type="hidden" name="status" value="">
+                                 <button type="submit" name="action" value="completed" class="btn btn-dark ml-2">Mark
+                                     Completed</button>
+                                 <button type="submit" name="action" value="inactive" class="btn btn-danger ml-1">Mark
+                                     Inactive</button>
                              </form>
                      </div>
                  </div>

--- a/Modules/CodeTrek/Resources/views/evaluate.blade.php
+++ b/Modules/CodeTrek/Resources/views/evaluate.blade.php
@@ -76,7 +76,6 @@
                              </form>
                              <form action="{{ route('codetrek.updateStatus', $applicant->id) }}" method="POST">
                                  @csrf
-                                 <input type="hidden" name="status" value="">
                                  <button type="submit" name="action" value="completed" class="btn btn-dark ml-2">Mark
                                      Completed</button>
                                  <button type="submit" name="action" value="inactive" class="btn btn-danger ml-1">Mark

--- a/Modules/CodeTrek/Routes/web.php
+++ b/Modules/CodeTrek/Routes/web.php
@@ -20,5 +20,5 @@ Route::prefix('codetrek')->middleware('auth')->group(function () {
     Route::get('/evaluate/{applicant}', 'CodeTrekController@evaluate')->name('codetrek.evaluate');
     Route::post('/action/{applicant}', 'CodeTrekApplicantRoundDetailController@takeAction')->name('codetrek.action');
     Route::post('/update-feedback/{applicantDetail}', 'CodeTrekApplicantRoundDetailController@update')->name('codetrek.update-feedback');
-    Route::post('/mark-inactive/{applicant}', 'CodeTrekApplicantRoundDetailController@markInactive')->name('codetrek.markInactive');
+    Route::post('/mark-inactive/{applicant}', 'CodeTrekApplicantRoundDetailController@updateStatus')->name('codetrek.updateStatus');
 });

--- a/Modules/CodeTrek/Routes/web.php
+++ b/Modules/CodeTrek/Routes/web.php
@@ -20,4 +20,5 @@ Route::prefix('codetrek')->middleware('auth')->group(function () {
     Route::get('/evaluate/{applicant}', 'CodeTrekController@evaluate')->name('codetrek.evaluate');
     Route::post('/action/{applicant}', 'CodeTrekApplicantRoundDetailController@takeAction')->name('codetrek.action');
     Route::post('/update-feedback/{applicantDetail}', 'CodeTrekApplicantRoundDetailController@update')->name('codetrek.update-feedback');
+    Route::post('/mark-inactive/{applicant}', 'CodeTrekApplicantRoundDetailController@markInactive')->name('codetrek.markInactive');
 });

--- a/Modules/CodeTrek/Routes/web.php
+++ b/Modules/CodeTrek/Routes/web.php
@@ -20,5 +20,5 @@ Route::prefix('codetrek')->middleware('auth')->group(function () {
     Route::get('/evaluate/{applicant}', 'CodeTrekController@evaluate')->name('codetrek.evaluate');
     Route::post('/action/{applicant}', 'CodeTrekApplicantRoundDetailController@takeAction')->name('codetrek.action');
     Route::post('/update-feedback/{applicantDetail}', 'CodeTrekApplicantRoundDetailController@update')->name('codetrek.update-feedback');
-    Route::post('/mark-inactive/{applicant}', 'CodeTrekApplicantRoundDetailController@updateStatus')->name('codetrek.updateStatus');
+    Route::post('/update-Status/{applicant}', 'CodeTrekApplicantRoundDetailController@updateStatus')->name('codetrek.updateStatus');
 });


### PR DESCRIPTION
Targets #2964 


### Description
There are many interns who get onboarded or leave midway for whatever reason, so no functionality has been built in for those applicants yet the status of all applicants is shown as active.
In the CodeTrek module, we have a button marked inactive Use the same button so that we can inactive the application as well.

### Checklist:
- [x] I have performed a self-review of my own code.
