### PR TITLE
feature/3005/New-tabs-for-every-status

### DIFF
--- a/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
@@ -85,14 +85,6 @@ class CodeTrekController extends Controller
 
         return redirect()->route('codetrek.index');
     }
-    public function filter(Request $request)
-    {
-        $status = request()->input('status', 'active');
-        $applicants = CodeTrekApplicant::where('status', $status)->get();
-        
-        return view('codetrek::index', compact('applicants'));
-    }
-
     /**
      * Remove the specified resource from storage.
      * @param int $id

--- a/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
+++ b/Modules/CodeTrek/Http/Controllers/CodeTrekController.php
@@ -25,7 +25,7 @@ class CodeTrekController extends Controller
      */
     public function index(Request $request)
     {
-        return view('codetrek::index', $this->service->getCodeTrekApplicants($request));
+        return view('codetrek::index', $this->service->getCodeTrekApplicants($request->all()));
     }
     /**
      * Show the form for creating a new resource.
@@ -84,6 +84,13 @@ class CodeTrekController extends Controller
         $applicant->delete();
 
         return redirect()->route('codetrek.index');
+    }
+    public function filter(Request $request)
+    {
+        $status = request()->input('status', 'active');
+        $applicants = CodeTrekApplicant::where('status', $status)->get();
+        
+        return view('codetrek::index', compact('applicants'));
     }
 
     /**

--- a/Modules/CodeTrek/Resources/views/index.blade.php
+++ b/Modules/CodeTrek/Resources/views/index.blade.php
@@ -45,15 +45,24 @@
             <div class='d-flex justify-content-between'>
                 <li class="nav-item mr-3">
                     <a href="{{ route('codetrek.index', ['status' => 'active']) }}"
-                        class="nav-link btn-nav {{ request()->input('status', 'active') == 'active' ? 'active' : '' }}">Active</a>
+                        class="nav-link btn-nav {{ request()->input('status', 'active') == 'active' ? 'active' : '' }}"
+                        onmouseover="this.style.transform='scale(1.1)'" onmouseout="this.style.transform='none'">
+                        <span class="d-inline-block h-18 w-20">{!! file_get_contents(public_path('icons/clipboard-check.svg')) !!}</span>
+                        Active</a>
                 </li>
                 <li class="nav-item mr-3">
                     <a href="{{ route('codetrek.index', ['status' => 'inactive']) }}"
-                        class="nav-link btn-nav {{ request()->input('status') == 'inactive' ? 'active' : '' }}">Inactive</a>
+                        class="nav-link btn-nav {{ request()->input('status') == 'inactive' ? 'active' : '' }}"
+                        onmouseover="this.style.transform='scale(1.1)'" onmouseout="this.style.transform='none'">
+                        <span class="d-inline-block h-18 w-20">{!! file_get_contents(public_path('icons/x-circle.svg')) !!}</span>
+                        Inactive</a>
                 </li>
                 <li class="nav-item mr-3">
                     <a href="{{ route('codetrek.index', ['status' => 'completed']) }}"
-                        class="nav-link btn-nav {{ request()->input('status') == 'completed' ? 'active' : '' }}">Completed</a>
+                        class="nav-link btn-nav {{ request()->input('status') == 'completed' ? 'active' : '' }}"
+                        onmouseover="this.style.transform='scale(1.1)'" onmouseout="this.style.transform='none'">
+                        <span class="d-inline-block h-18 w-20"> {!! file_get_contents(public_path('icons/person-check.svg')) !!} </span>
+                        Completed</a>
                 </li>
             </div>
         </ul>

--- a/Modules/CodeTrek/Resources/views/index.blade.php
+++ b/Modules/CodeTrek/Resources/views/index.blade.php
@@ -1,154 +1,179 @@
 @extends('codetrek::layouts.master')
 @section('heading', 'CodeTrek')
 @section('content')
-<div class="container" id="applicant">
-    <div class="col-lg-12 d-flex justify-content-between align-items-center mx-auto">
-        <div>
-             <h1>@yield('heading')</h1>
+    <div class="container" id="applicant">
+        <div class="col-lg-12 d-flex justify-content-between align-items-center mx-auto">
+            <div>
+                <h1>@yield('heading')</h1>
+            </div>
+            <div>
+                @include('codetrek::modals.add-applicant-modal')
+            </div>
         </div>
-        <div>
-            @include('codetrek::modals.add-applicant-modal')
-        </div>
-    </div>
-    <br><br>
-    <ul class="nav nav-pills d-flex justify-content-between">
-        @php
-          $request = request()->all();
-        @endphp
-        <div class="d-flex">
-        <li class="nav-item mr-3">
+        <br><br>
+        <ul class="nav nav-pills d-flex justify-content-between">
             @php
-                $request['tab'] = 'applicants';
+                $request = request()->all();
             @endphp
-             <a class="nav-link {{ (request()->input('tab', 'applicants') == 'applicants')  ? 'active' : '' }} " href="{{ route('codetrek.index', $request)  }}"><i class="fa fa-list-ul"></i> Applicants</a>
-        </li>
+            <div class="d-flex">
+                <li class="nav-item mr-3">
+                    @php
+                        $request['tab'] = 'applicants';
+                    @endphp
+                    <a class="nav-link {{ request()->input('tab', 'applicants') == 'applicants' ? 'active' : '' }} "
+                        href="{{ route('codetrek.index', $request) }}"><i class="fa fa-list-ul"></i> Applicants</a>
+                </li>
 
-        <li class="nav-item">
-            @php
-                $request['tab'] = 'reports';
-            @endphp
-            <a class="nav-link {{ request()->input('tab', 'active') == 'reports' ? 'active' : '' }}"  
-                href="{{ route('codetrek.index', $request) }}"><i class="fa fa-pie-chart"></i> Reports</a>
-        </li>
-        </div>
-        <form class="d-md-flex justify-content-between ml-md-3"
-        action="{{ route('codetrek.index') }}">
-        <div class="d-flex justify-content-end">
-            <input type="text" name="name" class="form-control" id="name"
-                placeholder="Enter the Applicant name" value={{ request()->get('name') }}>
-            <button class="btn btn-info ml-2 text-white">Search</button>
-        </div>
-        </form>
-    </ul>
-    @if (request()->input('tab', 'active') == 'active' || request()->tab == 'applicants')
-        <div>
-            <br>
-            <table class="table table-bordered table-striped">
-                <thead class="thead-dark">
-                    <tr class="text-center sticky-top">
-                        <th class="col-md-4">Name</th>
-                        <th class="col-md-2">Days in CodeTrek</th>
-                        <th>Status</th>
-                        <th>Feedbacks</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach ($applicants as $applicant)
-                        <tr>
-                            <td>
-                                <div class="d-flex align-items-center">
-                                    <div class="d-flex align-items-center">
-                                        <h4>{{ $applicant->first_name }} {{ $applicant->last_name }}</h4>
-                                    </div>
-                                </div>
-                                <span class="mr-1 text-truncate"><i
-                                        class="fa fa-envelope-o mr-1"></i>{{ $applicant->email }}</span>
-                                <br>
-                                @if ($applicant->phone)
-                                    <span class="mr-1"><i class="fa fa-phone mr-1"></i>{{ $applicant->phone }}</span>
-                                    <br>
-                                @endif
-                                <div>
-                                    @if ($applicant->university)
-                                        <span class="mr-1"><i
-                                                class="fa fa-university mr-1"></i>{{ $applicant->university }}</span>
-                                    @endif
-                                </div>
-                                <div class="mb-2 fz-xl-14 text-secondary d-flex flex-column">
-                                    <div class="d-flex text-white my-2">
-                                        <a href="{{ route('codetrek.edit', $applicant->id) }}"
-                                            class="btn-sm btn-primary mr-1 text-decoration-none" target="_self">View</a>
-                                        <a href="{{ route('codetrek.evaluate', $applicant->id) }}"
-                                            class="btn-sm btn-primary mr-1 text-decoration-none"
-                                            target="_self">Evaluate</a>
-                                    </div>
-                                </div>
-                            </td>
-                            <td>
-                                @php
-                                    $daysInCodetrek = now()->diffInDays($applicant->start_date);
-                                @endphp
-                                {{ $daysInCodetrek }} days
-                            </td>
-                            <td>{{ config('codetrek.status.' . $applicant->status . '.label') }}</td>
-                            <td>-</td>
+                <li class="nav-item">
+                    @php
+                        $request['tab'] = 'reports';
+                    @endphp
+                    <a class="nav-link {{ request()->input('tab', 'active') == 'reports' ? 'active' : '' }}"
+                        href="{{ route('codetrek.index', $request) }}"><i class="fa fa-pie-chart"></i> Reports</a>
+                </li>
+            </div>
+            <form class="d-md-flex justify-content-between ml-md-3" action="{{ route('codetrek.index') }}">
+                <div class="d-flex justify-content-end">
+                    <input type="text" name="name" class="form-control" id="name"
+                        placeholder="Enter the Applicant name" value={{ request()->get('name') }}>
+                    <input type="hidden" name="status" value="{{ $request['status'] ?? '' }}">
+                    <button class="btn btn-info ml-2 text-white">Search</button>
+                </div>
+            </form>
+        </ul>
+        <br>
+        <nav class="nav nav-tabs d-flex justify-content-around ">
+            <a href="{{ route('codetrek.index', ['status' => 'active']) }}"
+                class="nav-link {{ request()->input('status', 'active') == 'active' ? 'active' : '' }}">
+                <div class="d-flex flex-column align-items-center">
+                    <i class="fas fa-check-circle fa-2x"></i>
+                    <span class="mt-1">Active</span>
+                </div>
+            </a>
+            <a href="{{ route('codetrek.index', ['status' => 'inactive']) }}"
+                class="nav-link {{ request()->input('status') == 'inactive' ? 'active' : '' }}">
+                <div class="d-flex flex-column align-items-center">
+                    <i class="fa fa-times"></i>
+                    <span class="mt-1">Inactive</span>
+                </div>
+            </a>
+            <a href="{{ route('codetrek.index', ['status' => 'completed']) }}"
+                class="nav-link {{ request()->input('status') == 'completed' ? 'active' : '' }}">
+                <div class="d-flex flex-column align-items-center">
+                    <i class="fa fa-check"></i>
+                    <span class="mt-1">Completed</span>
+                </div>
+            </a>
+        </nav>
+        @if (request()->input('tab', 'active') == 'active' || request()->tab == 'applicants')
+            <div>
+                <br>
+                <table class="table table-bordered table-striped">
+                    <thead class="thead-dark">
+                        <tr class="text-center sticky-top">
+                            <th class="col-md-4">Name</th>
+                            <th class="col-md-2">Days in CodeTrek</th>
+                            <th>Status</th>
+                            <th>Feedbacks</th>
                         </tr>
-                    @endforeach
-                </tbody>
-            </table>
-        </div>
-    @elseif (request()->status == 'reports')
-        <div>
-            <br><br>
-            <p align="center">Coming Soon</p>
-        </div>
-    @endif
-</div>
+                    </thead>
+                    <tbody>
+                        @foreach ($applicants as $applicant)
+                            <tr>
+                                <td>
+                                    <div class="d-flex align-items-center">
+                                        <div class="d-flex align-items-center">
+                                            <h4>{{ $applicant->first_name }} {{ $applicant->last_name }}</h4>
+                                        </div>
+                                    </div>
+                                    <span class="mr-1 text-truncate"><i
+                                            class="fa fa-envelope-o mr-1"></i>{{ $applicant->email }}</span>
+                                    <br>
+                                    @if ($applicant->phone)
+                                        <span class="mr-1"><i class="fa fa-phone mr-1"></i>{{ $applicant->phone }}</span>
+                                        <br>
+                                    @endif
+                                    <div>
+                                        @if ($applicant->university)
+                                            <span class="mr-1"><i
+                                                    class="fa fa-university mr-1"></i>{{ $applicant->university }}</span>
+                                        @endif
+                                    </div>
+                                    <div class="mb-2 fz-xl-14 text-secondary d-flex flex-column">
+                                        <div class="d-flex text-white my-2">
+                                            <a href="{{ route('codetrek.edit', $applicant->id) }}"
+                                                class="btn-sm btn-primary mr-1 text-decoration-none" target="_self">View</a>
+                                            <a href="{{ route('codetrek.evaluate', $applicant->id) }}"
+                                                class="btn-sm btn-primary mr-1 text-decoration-none"
+                                                target="_self">Evaluate</a>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    @php
+                                        $daysInCodetrek = now()->diffInDays($applicant->start_date);
+                                    @endphp
+                                    {{ $daysInCodetrek }} days
+                                </td>
+                                <td>{{ config('codetrek.status.' . $applicant->status . '.label') }}</td>
+                                <td>-</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @elseif (request()->status == 'reports')
+            <div>
+                <br><br>
+                <p align="center">Coming Soon</p>
+            </div>
+        @endif
+    </div>
 @endsection
 @section('vue_scripts')
-<script>
-    new Vue({
-        el: '#applicant',
-        data() {
-            return {
-                first_name: '',
-                last_name: '',
-                email: '',
-                phone: '',
-                github_username: '',
-                start_date: '',
-                university: '',
-                course: '',
-                graduationyear: ''
-            }
-        },
-        methods: {
-            submitForm: async function(formId) {
-                $('.save-btn').attr('disabled', true);
-                let formData = new FormData(document.getElementById(formId));
-                await axios.post('{{ route('codetrek.store') }}', formData)
-                    .then((response) => {
-                        $('.save-btn').removeClass('btn-dark').addClass('btn-primary');
-                        $('.save-btn').attr('disabled', false);
-                        this.$toast.success("Applicant added successfully", {
-                            duration: 5000
-                        });
-                        $("#photoGallery").modal('hide');
-                        location.reload();
-                    })
-                    .catch((error) => {
-                        let errors = error.response.data.errors;
-                        $('.save-btn').attr('disabled', false);
-                        if (errors) {
-                            Object.keys(errors).forEach(function(key) {
-                                this.$toast.error(errors[key][0]);
+    <script>
+        new Vue({
+            el: '#applicant',
+            data() {
+                return {
+                    first_name: '',
+                    last_name: '',
+                    email: '',
+                    phone: '',
+                    github_username: '',
+                    start_date: '',
+                    university: '',
+                    course: '',
+                    graduationyear: ''
+                }
+            },
+            methods: {
+                submitForm: async function(formId) {
+                    $('.save-btn').attr('disabled', true);
+                    let formData = new FormData(document.getElementById(formId));
+                    await axios.post('{{ route('codetrek.store') }}', formData)
+                        .then((response) => {
+                            $('.save-btn').removeClass('btn-dark').addClass('btn-primary');
+                            $('.save-btn').attr('disabled', false);
+                            this.$toast.success("Applicant added successfully", {
+                                duration: 5000
                             });
-                        } else {
-                            this.$toast.error("Error submitting form, please fill required fields");
-                        }
-                    });
+                            $("#photoGallery").modal('hide');
+                            location.reload();
+                        })
+                        .catch((error) => {
+                            let errors = error.response.data.errors;
+                            $('.save-btn').attr('disabled', false);
+                            if (errors) {
+                                Object.keys(errors).forEach(function(key) {
+                                    this.$toast.error(errors[key][0]);
+                                });
+                            } else {
+                                this.$toast.error("Error submitting form, please fill required fields");
+                            }
+                        });
+                }
             }
-        }
-    });
-</script>
+        });
+    </script>
 @endsection

--- a/Modules/CodeTrek/Resources/views/index.blade.php
+++ b/Modules/CodeTrek/Resources/views/index.blade.php
@@ -41,29 +41,22 @@
             </form>
         </ul>
         <br>
-        <nav class="nav nav-tabs d-flex justify-content-around ">
-            <a href="{{ route('codetrek.index', ['status' => 'active']) }}"
-                class="nav-link {{ request()->input('status', 'active') == 'active' ? 'active' : '' }}">
-                <div class="d-flex flex-column align-items-center">
-                    <i class="fas fa-check-circle fa-2x"></i>
-                    <span class="mt-1">Active</span>
-                </div>
-            </a>
-            <a href="{{ route('codetrek.index', ['status' => 'inactive']) }}"
-                class="nav-link {{ request()->input('status') == 'inactive' ? 'active' : '' }}">
-                <div class="d-flex flex-column align-items-center">
-                    <i class="fa fa-times"></i>
-                    <span class="mt-1">Inactive</span>
-                </div>
-            </a>
-            <a href="{{ route('codetrek.index', ['status' => 'completed']) }}"
-                class="nav-link {{ request()->input('status') == 'completed' ? 'active' : '' }}">
-                <div class="d-flex flex-column align-items-center">
-                    <i class="fa fa-check"></i>
-                    <span class="mt-1">Completed</span>
-                </div>
-            </a>
-        </nav>
+        <ul class="nav nav-pills d-flex justify-content-between">
+            <div class='d-flex justify-content-between'>
+                <li class="nav-item mr-3">
+                    <a href="{{ route('codetrek.index', ['status' => 'active']) }}"
+                        class="nav-link btn-nav {{ request()->input('status', 'active') == 'active' ? 'active' : '' }}">Active</a>
+                </li>
+                <li class="nav-item mr-3">
+                    <a href="{{ route('codetrek.index', ['status' => 'inactive']) }}"
+                        class="nav-link btn-nav {{ request()->input('status') == 'inactive' ? 'active' : '' }}">Inactive</a>
+                </li>
+                <li class="nav-item mr-3">
+                    <a href="{{ route('codetrek.index', ['status' => 'completed']) }}"
+                        class="nav-link btn-nav {{ request()->input('status') == 'completed' ? 'active' : '' }}">Completed</a>
+                </li>
+            </div>
+        </ul>
         @if (request()->input('tab', 'active') == 'active' || request()->tab == 'applicants')
             <div>
                 <br>

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -8,12 +8,17 @@ use Modules\CodeTrek\Entities\CodeTrekApplicantRoundDetail;
 
 class CodeTrekService
 {
-    public function getCodeTrekApplicants(Request $request)
+    public function getCodeTrekApplicants($data = [])
     {
-        $search = $request->get('name');
-        $applicants = $search ? CodeTrekApplicant::where('first_name', 'LIKE', "%$search%")
-        ->orWhere('last_name', 'LIKE', "%$search%")
-        ->get() : CodeTrekApplicant::all();
+        $search = $data['name'] ?? null;
+        $status = $data['status'] ?? null;
+        if (!$status) {
+            return ['applicants' => CodeTrekApplicant::all()];
+        }
+        $query = CodeTrekApplicant::where('status', $status);
+        $applicants = $search ? $query->where('first_name', 'LIKE', "%$search%")
+            ->orWhere('last_name', 'LIKE', "%$search%")
+            ->get() : $query->get();
 
         return ['applicants' => $applicants];
     }

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -11,10 +11,6 @@ class CodeTrekService
     {
         $search = $data['name'] ?? null;
         $status = $data['status'] ?? 'active';
-
-        if (! $status) {
-            return ['applicants' => CodeTrekApplicant::all()];
-        }
         $query = CodeTrekApplicant::where('status', $status);
         $applicants = $search ? $query->where('first_name', 'LIKE', "%$search%")
             ->orWhere('last_name', 'LIKE', "%$search%")

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -12,7 +12,7 @@ class CodeTrekService
         $search = $data['name'] ?? null;
         $status = $data['status'] ?? 'active';
 
-        if (!$status) {
+        if (! $status) {
             return ['applicants' => CodeTrekApplicant::all()];
         }
         $query = CodeTrekApplicant::where('status', $status);

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -2,7 +2,6 @@
 
 namespace Modules\CodeTrek\Services;
 
-use Illuminate\Http\Request;
 use Modules\CodeTrek\Entities\CodeTrekApplicant;
 use Modules\CodeTrek\Entities\CodeTrekApplicantRoundDetail;
 
@@ -11,7 +10,8 @@ class CodeTrekService
     public function getCodeTrekApplicants($data = [])
     {
         $search = $data['name'] ?? null;
-        $status = $data['status'] ?? null;
+        $status = $data['status'] ?? 'active';
+
         if (!$status) {
             return ['applicants' => CodeTrekApplicant::all()];
         }

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -164,7 +164,7 @@
     @endcan
     @can('codetrek.view')
         <li class="nav-item">
-            <a class="nav-item nav-link" href="{{('/codetrek') }}">CodeTrek</a>
+            <a class="nav-item nav-link" href="{{('/codetrek?status=active') }}">CodeTrek</a>
         </li>
     @endcan
     @can('media.view')

--- a/resources/views/layouts/navbar.blade.php
+++ b/resources/views/layouts/navbar.blade.php
@@ -164,7 +164,7 @@
     @endcan
     @can('codetrek.view')
         <li class="nav-item">
-            <a class="nav-item nav-link" href="{{('/codetrek?status=active') }}">CodeTrek</a>
+            <a class="nav-item nav-link" href="{{ route('codetrek.index') }}">CodeTrek</a>
         </li>
     @endcan
     @can('media.view')


### PR DESCRIPTION
Targets #3005 

In the CodeTrek index page, all the applicants are shown, so it is difficult for the users to find which applicant is 'inactive' 'completed' and 'active' For this I make separate tabs for every status.

### Checklist:
- [x] I have performed a self-review of my own code.
