### PR TITLE
Show clients status count on menu header

### DIFF
--- a/Modules/Client/Resources/views/index.blade.php
+++ b/Modules/Client/Resources/views/index.blade.php
@@ -9,7 +9,7 @@
         @endcan
     </div>
     <div class="d-md-flex justify-content-between mt-5 mb-2">
-        <h4 class="mb-1 pb-1">{{ config('client.status')[request()->input('status', 'active')] }} Clients ({{ $count }})</h4>
+        <h4 class="mb-1 pb-1">{{ config('client.status')[request()->input('status', 'active')] }} Clients</h4>
         <div>
             <form action="{{ route('client.index') }}" method="GET">
                 <div class="d-flex align-items-center">

--- a/Modules/Client/Resources/views/menu_header.blade.php
+++ b/Modules/Client/Resources/views/menu_header.blade.php
@@ -6,13 +6,13 @@
         @php
             $request['status'] = 'active';
         @endphp
-        <a class="nav-link {{ (request()->input('status', 'active') == 'active')  ? 'active' : '' }}" href="{{ route('client.index', $request)  }}">Active Clients</a>
+        <a class="nav-link {{ (request()->input('status', 'active') == 'active')  ? 'active' : '' }}" href="{{ route('client.index', $request)  }}">Active Clients {{  (request()->input('status', 'active') == 'active') ?  '(' . $count . ')' : null }}</a>
     </li>
 
     <li class="nav-item">
         @php
             $request['status'] = 'inactive';
         @endphp
-        <a class="nav-link {{ (request()->input('status', 'active') == 'inactive') ? 'active' : '' }}"  href="{{ route('client.index', $request)  }}">Inactive Clients</a>
+        <a class="nav-link {{ (request()->input('status', 'active') == 'inactive') ? 'active' : '' }}"  href="{{ route('client.index', $request)  }}">Inactive Clients {{  (request()->input('status', 'active') == 'inactive') ?  '(' . $count . ')' : null }}</a>
     </li>
 </ul>

--- a/Modules/Client/Resources/views/menu_header.blade.php
+++ b/Modules/Client/Resources/views/menu_header.blade.php
@@ -6,13 +6,13 @@
         @php
             $request['status'] = 'active';
         @endphp
-        <a class="nav-link {{ (request()->input('status', 'active') == 'active')  ? 'active' : '' }}" href="{{ route('client.index', $request)  }}">Active Clients {{ '('.$activeCount.')' }}</a>
+        <a class="nav-link {{ (request()->input('status', 'active') == 'active')  ? 'active' : '' }}" href="{{ route('client.index', $request)  }}">Active Clients ({{$activeClientsCount}})</a>
     </li>
 
     <li class="nav-item">
         @php
             $request['status'] = 'inactive';
         @endphp
-        <a class="nav-link {{ (request()->input('status', 'active') == 'inactive') ? 'active' : '' }}"  href="{{ route('client.index', $request)  }}">Inactive Clients {{ '('.$inactiveCount.')' }}</a>
+        <a class="nav-link {{ (request()->input('status', 'active') == 'inactive') ? 'active' : '' }}"  href="{{ route('client.index', $request)  }}">Inactive Clients ({{$inactiveClientsCount}})</a>
     </li>
 </ul>

--- a/Modules/Client/Resources/views/menu_header.blade.php
+++ b/Modules/Client/Resources/views/menu_header.blade.php
@@ -6,13 +6,13 @@
         @php
             $request['status'] = 'active';
         @endphp
-        <a class="nav-link {{ (request()->input('status', 'active') == 'active')  ? 'active' : '' }}" href="{{ route('client.index', $request)  }}">Active Clients {{  (request()->input('status', 'active') == 'active') ?  '(' . $count . ')' : null }}</a>
+        <a class="nav-link {{ (request()->input('status', 'active') == 'active')  ? 'active' : '' }}" href="{{ route('client.index', $request)  }}">Active Clients {{ '('.$activeCount.')' }}</a>
     </li>
 
     <li class="nav-item">
         @php
             $request['status'] = 'inactive';
         @endphp
-        <a class="nav-link {{ (request()->input('status', 'active') == 'inactive') ? 'active' : '' }}"  href="{{ route('client.index', $request)  }}">Inactive Clients {{  (request()->input('status', 'active') == 'inactive') ?  '(' . $count . ')' : null }}</a>
+        <a class="nav-link {{ (request()->input('status', 'active') == 'inactive') ? 'active' : '' }}"  href="{{ route('client.index', $request)  }}">Inactive Clients {{ '('.$inactiveCount.')' }}</a>
     </li>
 </ul>

--- a/Modules/Client/Services/ClientService.php
+++ b/Modules/Client/Services/ClientService.php
@@ -5,6 +5,7 @@ namespace Modules\Client\Services;
 use App\Models\Country;
 use Modules\User\Entities\User;
 use Modules\Client\Entities\Client;
+use Modules\Client\Entities\Modals;
 use Modules\Client\Entities\ClientAddress;
 use Modules\Client\Entities\ClientBillingDetail;
 use Modules\Client\Entities\ClientContactPerson;
@@ -43,7 +44,10 @@ class ClientService implements ClientServiceContract
             $clients = $clients->diff($client->linkedAsDepartment);
         }
 
-        return ['clients' => $clients, 'count' => $count];
+        $activeCount = Client::where('status', 'active')->count();
+        $inactiveCount = Client::where('status', 'inactive')->count();
+
+        return ['clients' => $clients, 'count' => $count,'activeCount' => $activeCount, 'inactiveCount'=> $inactiveCount];
     }
 
     public function create()

--- a/Modules/Client/Services/ClientService.php
+++ b/Modules/Client/Services/ClientService.php
@@ -47,7 +47,7 @@ class ClientService implements ClientServiceContract
         $activeCount = Client::where('status', 'active')->count();
         $inactiveCount = Client::where('status', 'inactive')->count();
 
-        return ['clients' => $clients, 'count' => $count,'activeCount' => $activeCount, 'inactiveCount'=> $inactiveCount];
+        return ['clients' => $clients, 'count' => $count, 'activeCount' => $activeCount, 'inactiveCount'=> $inactiveCount];
     }
 
     public function create()

--- a/Modules/Client/Services/ClientService.php
+++ b/Modules/Client/Services/ClientService.php
@@ -43,10 +43,10 @@ class ClientService implements ClientServiceContract
             $clients = $clients->diff($client->linkedAsDepartment);
         }
 
-        $activeCount = Client::where('status', 'active')->count();
-        $inactiveCount = Client::where('status', 'inactive')->count();
+        $activeClientsCount = Client::where('status', 'active')->count();
+        $inactiveClientsCount = Client::where('status', 'inactive')->count();
 
-        return ['clients' => $clients, 'count' => $count, 'activeCount' => $activeCount, 'inactiveCount'=> $inactiveCount];
+        return ['clients' => $clients, 'count' => $count, 'activeClientsCount' => $activeClientsCount, 'inactiveClientsCount'=> $inactiveClientsCount];
     }
 
     public function create()

--- a/Modules/Client/Services/ClientService.php
+++ b/Modules/Client/Services/ClientService.php
@@ -5,7 +5,6 @@ namespace Modules\Client\Services;
 use App\Models\Country;
 use Modules\User\Entities\User;
 use Modules\Client\Entities\Client;
-use Modules\Client\Entities\Modals;
 use Modules\Client\Entities\ClientAddress;
 use Modules\Client\Entities\ClientBillingDetail;
 use Modules\Client\Entities\ClientContactPerson;


### PR DESCRIPTION
**Targets #3063** 

### Description
---
To display the count of active and inactive clients on their respective buttons in the client module.

---
**Previous client module UI:-**
![235961414-329cf483-6825-4d2c-87ed-8fd7ee8861fb](https://github.com/ColoredCow/portal/assets/120373044/c7636083-df67-4f0a-b1d1-31c84e7027f2)
---
---
**Now client module UI:-**
![Screenshot (103)](https://github.com/ColoredCow/portal/assets/120373044/21aa796b-72be-4382-b925-8a077cc4e9b7)
---
 
### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
