### PR TITLE
Display Designations in Resource Required Column on Project Resource …

### DIFF
--- a/Modules/Project/Resources/views/resource-requirement.blade.php
+++ b/Modules/Project/Resources/views/resource-requirement.blade.php
@@ -71,7 +71,7 @@
                                 </td>  
                                 <td> 
                                     @foreach ($projectData['countByDesignation'] as $designationName => $count)
-                                         <div> {{ $designationName }} : {{ $count }} </div>
+                                        <div> {{ $designationName }} : {{ $count }} </div>
                                     @endforeach
                                 </td> 
                             </tr>

--- a/Modules/Project/Resources/views/resource-requirement.blade.php
+++ b/Modules/Project/Resources/views/resource-requirement.blade.php
@@ -70,7 +70,9 @@
                                     @endforeach
                                 </td>  
                                 <td> 
-                                    <div class="d-flex justify-content-center"> {{ $projectData['additionalResourceRequired'] }} </div>
+                                    @foreach ($projectData['countByDesignation'] as $designationName => $count)
+                                         <div> {{ $designationName }} : {{ $count }} </div>
+                                    @endforeach
                                 </td> 
                             </tr>
                             @endforeach

--- a/Modules/Project/Resources/views/subviews/edit-project-financial-details.blade.php
+++ b/Modules/Project/Resources/views/subviews/edit-project-financial-details.blade.php
@@ -3,7 +3,7 @@
         <form action="{{ route('project.update', $project) }}" method="POST" id="updateProjectFinancialDetails" enctype="multipart/form-data">
             @csrf
             <input type="hidden" value="project_financial_details" name="update_section">
-            <input type="hidden" name="currency" value="{{ $project->client->country->currency }}">
+            {{-- <input type="hidden" name="currency" value="{{ $project->client->country->currency }}"> --}}
             <div class="card-body">
                 <div class="form-row">
                     <div class="form-group col-md-5">
@@ -12,7 +12,7 @@
                             <div class="input-group mr-5">
                                 <input value="{{ optional($project->billingDetail)->service_rates }}" name="service_rates" type="number" step="0.01" class="form-control" placeholder="amount">
                                 <div class="input-group-append">
-                                    <span class="input-group-text">{{ $project->client->country->currency }}</span>
+                                    <span class="input-group-text">{{ optional($project->client->country)->currency }}</span>
                                 </div>
                             </div>
 

--- a/Modules/Project/Resources/views/subviews/edit-project-financial-details.blade.php
+++ b/Modules/Project/Resources/views/subviews/edit-project-financial-details.blade.php
@@ -3,7 +3,7 @@
         <form action="{{ route('project.update', $project) }}" method="POST" id="updateProjectFinancialDetails" enctype="multipart/form-data">
             @csrf
             <input type="hidden" value="project_financial_details" name="update_section">
-            {{-- <input type="hidden" name="currency" value="{{ $project->client->country->currency }}"> --}}
+            <input type="hidden" name="currency" value="{{ $project->client->country->currency }}">
             <div class="card-body">
                 <div class="form-row">
                     <div class="form-group col-md-5">
@@ -12,7 +12,7 @@
                             <div class="input-group mr-5">
                                 <input value="{{ optional($project->billingDetail)->service_rates }}" name="service_rates" type="number" step="0.01" class="form-control" placeholder="amount">
                                 <div class="input-group-append">
-                                    <span class="input-group-text">{{ optional($project->client->country)->currency }}</span>
+                                    <span class="input-group-text">{{ $project->client->country->currency }}</span>
                                 </div>
                             </div>
 

--- a/Modules/Project/Services/ProjectService.php
+++ b/Modules/Project/Services/ProjectService.php
@@ -502,6 +502,8 @@ class ProjectService implements ProjectServiceContract
                 if ($totalResourceDeployedCount > 0) {
                     $projectData['currentTeamMemberCountByDesignation'][$designations[$designationName]] = $totalResourceDeployedCount;
                 }
+                $count = $totalResourceRequirementCount - $totalResourceDeployedCount;
+                $projectData['countByDesignation'][$designations[$designationName]] = $count;
             }
             $data[$project->client->name][$project->name] = $projectData;
         }

--- a/Modules/Project/Services/ProjectService.php
+++ b/Modules/Project/Services/ProjectService.php
@@ -465,50 +465,57 @@ class ProjectService implements ProjectServiceContract
     public function getProjectsWithTeamMemberRequirementData($request)
     {
         $projectsWithTeamMemberRequirement = Project::query()
-        ->with('client')
-        ->status('active')
-        ->withCount('getTeamMembers as team_member_count')
-        ->withSum('resourceRequirement as team_member_needed', 'total_requirement')
-        ->havingRaw('team_member_needed - team_member_count')
-        ->when($request, function ($query, $request) {
-            return $query->where('name', 'like', '%' . $request['name'] . '%');
-        })
-        ->get();
+    ->with('client')
+    ->status('active')
+    ->withCount('getTeamMembers as team_member_count')
+    ->withSum('resourceRequirement as team_member_needed', 'total_requirement')
+    ->havingRaw('team_member_needed - team_member_count')
+    ->when($request, function ($query, $request) {
+        return $query->where('name', 'like', '%' . $request['name'] . '%');
+    })
+    ->get();
 
-        $totalAdditionalResourceRequired = [];
-        $data = [];
-        $totalAdditionalResourceRequired = 0;
-        foreach ($projectsWithTeamMemberRequirement as $project) {
-            $count = $project->team_member_needed - $project->team_member_count;
-            $totalAdditionalResourceRequired += $count;
-            $projectData = [
-                'totalResourceRequirement' => $project->team_member_needed,
-                'totalResourceDeployed' => $project->team_member_count,
-                'additionalResourceRequired' => $project->team_member_needed - $project->team_member_count,
-                'teamMemberNeededByDesignation' => [],
-                'currentTeamMemberCountByDesignation' => [],
-                'object' => $project,
-            ];
+$totalAdditionalResourceRequired = 0;
+$data = [];
 
-            $designations = $this->getDesignations();
-            $designationKeys = array_keys($designations);
+foreach ($projectsWithTeamMemberRequirement as $project) {
+    $count = $project->team_member_needed - $project->team_member_count;
+    $totalAdditionalResourceRequired += $count;
 
-            foreach ($designationKeys as $designationName) {
-                $totalResourceRequirementCount = $project->getResourceRequirementByDesignation($designationName)->total_requirement;
-                if ($totalResourceRequirementCount > 0) {
-                    $projectData['teamMemberNeededByDesignation'][$designations[$designationName]] = $totalResourceRequirementCount;
-                }
-                $totalResourceDeployedCount = $project->getDeployedCountForDesignation($designationName);
-                if ($totalResourceDeployedCount > 0) {
-                    $projectData['currentTeamMemberCountByDesignation'][$designations[$designationName]] = $totalResourceDeployedCount;
-                }
-            }
-            $data[$project->client->name][$project->name] = $projectData;
+    $projectData = [
+        'totalResourceRequirement' => $project->team_member_needed,
+        'totalResourceDeployed' => $project->team_member_count,
+        'additionalResourceRequired' => $project->team_member_needed - $project->team_member_count,
+        'teamMemberNeededByDesignation' => [],
+        'currentTeamMemberCountByDesignation' => [],
+        'object' => $project,
+    ];
+
+    $designations = $this->getDesignations();
+    $designationKeys = array_keys($designations);
+
+    foreach ($designationKeys as $designationName) {
+        $totalResourceRequirementCount = $project->getResourceRequirementByDesignation($designationName)->total_requirement;
+        if ($totalResourceRequirementCount > 0) {
+            $projectData['teamMemberNeededByDesignation'][$designations[$designationName]] = $totalResourceRequirementCount;
         }
 
-        return [
-            'totalCount' => $totalAdditionalResourceRequired,
-            'data' => $data,
-        ];
+        $totalResourceDeployedCount = $project->getDeployedCountForDesignation($designationName);
+        if ($totalResourceDeployedCount > 0) {
+            $projectData['currentTeamMemberCountByDesignation'][$designations[$designationName]] = $totalResourceDeployedCount;
+        }
+
+        $count = $totalResourceRequirementCount - $totalResourceDeployedCount;
+        $projectData['countByDesignation'][$designations[$designationName]] = $count;
+    }
+
+    $data[$project->client->name][$project->name] = $projectData;
+}
+
+return [
+    'totalCount' => $totalAdditionalResourceRequired,
+    'data' => $data,
+];
+
     }
 }

--- a/Modules/Project/Services/ProjectService.php
+++ b/Modules/Project/Services/ProjectService.php
@@ -154,7 +154,7 @@ class ProjectService implements ProjectServiceContract
     public function updateProjectData($data, $project)
     {
         $updateSection = $data['update_section'] ?? '';
-        if (!$updateSection) {
+        if (! $updateSection) {
             return false;
         }
 
@@ -211,7 +211,7 @@ class ProjectService implements ProjectServiceContract
         if ($data['status'] == 'active' || $data['status'] == 'halted') {
             $project->client->update(['status' => 'active']);
         } else {
-            if (!$project->client->projects()->where('status', 'active')->exists()) {
+            if (! $project->client->projects()->where('status', 'active')->exists()) {
                 $project->client->update(['status' => 'inactive']);
             }
             $project->getTeamMembers()->update(['ended_on' => now()]);
@@ -244,7 +244,7 @@ class ProjectService implements ProjectServiceContract
                     $member->update($tempArray);
                 }
             }
-            if (!$flag) {
+            if (! $flag) {
                 $member->update(['ended_on' => Carbon::now()]);
             }
         }
@@ -265,7 +265,7 @@ class ProjectService implements ProjectServiceContract
 
     private function updateProjectRepositories($data, $project)
     {
-        if (!isset($data['url'])) {
+        if (! isset($data['url'])) {
             $project->repositories()->delete();
 
             return;
@@ -349,7 +349,7 @@ class ProjectService implements ProjectServiceContract
         $numberOfWorkingDays = 0;
         $weekend = ['Saturday', 'Sunday'];
         foreach ($period as $date) {
-            if (!in_array($date->format('l'), $weekend)) {
+            if (! in_array($date->format('l'), $weekend)) {
                 $numberOfWorkingDays++;
             }
         }
@@ -445,7 +445,7 @@ class ProjectService implements ProjectServiceContract
     {
         $teamMembers = [];
         foreach ($employees as $employee) {
-            if (!$employee->user) {
+            if (! $employee->user) {
                 continue;
             }
             foreach ($employee->user->activeProjectTeamMembers as $activeProjectTeamMember) {
@@ -516,6 +516,5 @@ class ProjectService implements ProjectServiceContract
             'totalCount' => $totalAdditionalResourceRequired,
             'data' => $data,
         ];
-
     }
 }


### PR DESCRIPTION
Targets #3006

### Description:
This functionality display designations in the "Resource Required" column on the Project Resource page. Previously, only the total count of additional resources required was shown in that column. With this update, the individual designations along with their respective counts are now displayed.

### Screenshot:
**Previous UI**
![Screenshot (68)](https://user-images.githubusercontent.com/106467597/233032721-da187e16-ceda-4e02-bf79-ab342c793a82.png)
**Latest Fixed UI**
![image](https://github.com/ColoredCow/portal/assets/121417968/002891c9-3dc3-49fb-aefa-56e2a2e800be)

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
