### PR TITLE
#3129 Display Only Active Applicants in CodeTreak Applicant Sidebar and Resolve Overlapping with Other Modules.

### DIFF
--- a/Modules/CodeTrek/Resources/views/sidebar.blade.php
+++ b/Modules/CodeTrek/Resources/views/sidebar.blade.php
@@ -2,14 +2,12 @@
     <h5 class="fw-bold border-bottom pb-2">CodeTrek Applicants</h5>
     <ul class="applicant-list list-unstyled">
         @foreach ($codeTrekApplicants as $codeTrekApplicant)
-            @if ($codeTrekApplicant->status == 'active')
-                <li data-id="{{ $codeTrekApplicant->id }}" class="d-flex align-items-center">
-                    <i class="fa fa-user mr-1"></i>
-                    <h6 class="ml-1">
-                        {{ $codeTrekApplicant->first_name }} {{ $codeTrekApplicant->last_name }}
-                    </h6>
-                </li>
-            @endif
+        <li data-id="{{ $codeTrekApplicant->id }}" class="d-flex align-items-center">
+            <i class="fa fa-user mr-1"></i>
+            <h6 class="ml-1">
+                {{ $codeTrekApplicant->first_name }} {{ $codeTrekApplicant->last_name }}
+            </h6>
+        </li>
         @endforeach
     </ul>
 </div>

--- a/Modules/CodeTrek/Resources/views/sidebar.blade.php
+++ b/Modules/CodeTrek/Resources/views/sidebar.blade.php
@@ -2,12 +2,14 @@
     <h5 class="fw-bold border-bottom pb-2">CodeTrek Applicants</h5>
     <ul class="applicant-list list-unstyled">
         @foreach ($codeTrekApplicants as $codeTrekApplicant)
-        <li data-id="{{ $codeTrekApplicant->id }}" class="d-flex align-items-center">
-            <i class="fa fa-user mr-1"></i>
-            <h6 class="ml-1">
-                {{ $codeTrekApplicant->first_name }} {{ $codeTrekApplicant->last_name }}
-            </h6>
-        </li>
+            @if ($codeTrekApplicant->status == 'active')
+                <li data-id="{{ $codeTrekApplicant->id }}" class="d-flex align-items-center">
+                    <i class="fa fa-user mr-1"></i>
+                    <h6 class="ml-1">
+                        {{ $codeTrekApplicant->first_name }} {{ $codeTrekApplicant->last_name }}
+                    </h6>
+                </li>
+            @endif
         @endforeach
     </ul>
 </div>

--- a/app/Http/View/Composers/CodeTrekApplicantsComposer.php
+++ b/app/Http/View/Composers/CodeTrekApplicantsComposer.php
@@ -9,8 +9,10 @@ class CodeTrekApplicantsComposer
 {
     public function compose(View $view)
     {
-        $codeTrekApplicants = CodeTrekApplicant::orderBy('first_name', 'asc')->get();
+        $codeTrekApplicants = CodeTrekApplicant::where('status','active')
+        ->orderBy('first_name', 'asc')
+        ->get();
 
-        $view->with('codeTrekApplicants', $codeTrekApplicants);
+    $view->with('codeTrekApplicants', $codeTrekApplicants);    
     }
 }

--- a/app/Http/View/Composers/CodeTrekApplicantsComposer.php
+++ b/app/Http/View/Composers/CodeTrekApplicantsComposer.php
@@ -9,7 +9,7 @@ class CodeTrekApplicantsComposer
 {
     public function compose(View $view)
     {
-        $codeTrekApplicants = CodeTrekApplicant::where('status','active')
+        $codeTrekApplicants = CodeTrekApplicant::where('status', 'active')
         ->orderBy('first_name', 'asc')
         ->get();
 

--- a/app/Http/View/Composers/CodeTrekApplicantsComposer.php
+++ b/app/Http/View/Composers/CodeTrekApplicantsComposer.php
@@ -13,6 +13,6 @@ class CodeTrekApplicantsComposer
         ->orderBy('first_name', 'asc')
         ->get();
 
-    $view->with('codeTrekApplicants', $codeTrekApplicants);    
+        $view->with('codeTrekApplicants', $codeTrekApplicants);
     }
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -818,7 +818,7 @@ span.total-chart-count{
 	transition: right 0.3s ease-in-out;
 	overflow-y: scroll;
 	height: 720px;
-	z-index: 999;
+	z-index: 9999;
 }
 
 .applicant-list li {


### PR DESCRIPTION
Targets #3129 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->

<!--- Please complete the following steps and check these boxes before filing your PR: -->

### Description
<!--- Describe your changes in detail -->
<!--- Why these changes are required? What existing problem does the pull request solve? -->

Made changes so only to display active applicants in CodeTreak Applicant Sidebar.
Resolved Overlapping of CodeTreak Applicant Sidebar with other modules.
These changes were required as the user will get to see only active applicant. Opening the sidebar does not overlaps with tables in other modules, resulting in better view for user.
 This pull request , solves the issue and displays Active applicants only in CodeTreak Applicant Sidebar and the sidebar does not overlaps with other modules.

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.

### Approach -
Checked the view page and tried to figure , how data is passed in view page.
Checked the css file for sidebar.

### Expected Time - 4-6  hours.
Code review and documentation: 0.5-1 hour.
then ,
Making the required changes : 1 hour.

For testing, code review, and documentation : 1 hour.

### Total time spent in task =3 hours

### Changes required in code -
As there was no condition to display active applicants, so added a condition where it displays active applicants only instead of all. 
Made changes in stack order of task i.e z-index. So sidebar opens up and does not overlaps.