### PR TITLE
Update the version of Node.jd and NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "cypress-open": "node_modules/.bin/cypress open",
         "cypress-record": "node_modules/.bin/cypress run --record --key",
         "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "development": "cross-env  NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch-poll": "npm run watch -- --watch-poll",
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
         "cypress-record": "node_modules/.bin/cypress run --record --key",
         "dev": "npm run development",
         "development": "cross-env  NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "watch": "cross-env  NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch-poll": "npm run watch -- --watch-poll",
-        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "hot": "cross-env  NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "production": "cross-env  NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prepare": "husky install"
     },
     "devDependencies": {


### PR DESCRIPTION
Targets #3136


### Description
The issue of the CSS file not being loaded correctly after updating the Node.js and NPM versions in the portal's tech stack.


### Changes Made:

- Analyzed the issue and identified that the problem is related to the updated versions of Node.js and NPM.
- Researched and investigated potential solutions. Link : https://levelup.gitconnected.com/how-to-fix-the-err-ossl-evp-unsupported-error-in-node-js-197082f42185
- Identified the root cause of the error and implemented the necessary changes to resolve it


### Testing:

- Performed extensive testing to ensure the stability and functionality of the portal after the changes.
- Tested the portal  to verify the weather the it is working properly.

### Explanation for adding NODE_OPTIONS=--openssl-legacy-provider to the code:

To address the ERR_OSSL_EVP_UNSUPPORTED error occurring in Node.js 17, it has been observed that setting the NODE_OPTIONS environment variable to "--openssl-legacy-provider" can help mitigate the issue.

By adding NODE_OPTIONS=--openssl-legacy-provider to the code, you are instructing Node.js to use the legacy OpenSSL provider instead of the default OpenSSL 3.0 provider. This can help resolve compatibility issues and allow the previously supported algorithms and key sizes to be used.

Including this information in the pull request can help provide context and transparency about the solution implemented to address the ERR_OSSL_EVP_UNSUPPORTED error in Node.js 17.

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
