### PR TITLE
Show project to KeyAccountManger

### DIFF
--- a/Modules/Project/Entities/Project.php
+++ b/Modules/Project/Entities/Project.php
@@ -111,6 +111,11 @@ class Project extends Model implements Auditable
         return $this->hasMany(ProjectTeamMember::class)->whereNULL('ended_on');
     }
 
+    public function getKeyAccountManagerAttribute()
+    {
+        return $this->client->keyAccountManager;
+    }
+
     public function getTeamMembersGroupedByEngagement()
     {
         return $this->getTeamMembers()->select('billing_engagement', DB::raw('count(*) as resource_count'))->groupBy('billing_engagement')->get();

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -115,12 +115,12 @@
                                                 <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
                                             @else
                                                 @php
-                                                    $teamMemberIds = $project->getTeamMembers->pluck('team_member_id')->toArray()
+                                                    $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
                                                     $keyAccountmanager = $project->getKeyAccountManagerAttribute();
                                                     $userId = auth()->user()->id;
                                                     $keyAccountmanagerId = $keyAccountmanager ? $keyAccountmanager->id : null;
                                                 @endphp
-                                                @if (in_array(auth()->user()->id, $teamMemberIds) || $keyAccountmanagerId === $userId)
+                                                @if (in_array(auth()->user()->id, $team_member_ids) || $keyAccountmanagerId === $userId)
                                                     <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
                                                 @else
                                                     <span class="pr-2 pr-xl-2">

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -13,14 +13,15 @@
             @include('project::menu_header')
             @can('projects.create')
                 <span class='mt-4'>
-                    
+
                     <a href="{{ route('project.create') }}" class="btn btn-success text-white"><i class="fa fa-plus"></i>
                         {{ __('Add new project') }}</a>
                 </span>
             @endcan
         </div>
         <div class="text-right mb-2">
-            <button class="btn btn-info text-white" data-toggle="modal" data-target="#modalExcelFilters">Export To Excel</button>
+            <button class="btn btn-info text-white" data-toggle="modal" data-target="#modalExcelFilters">Export To
+                Excel</button>
         </div>
         <div class="mb-2">
             <form class="d-md-flex justify-content-between ml-md-3"
@@ -37,8 +38,13 @@
                     <select class="fz-14 fz-lg-16 p-1 bg-info ml-3 my-auto text-white rounded border-0" name="projects"
                         onchange="this.form.submit()">
                         @php
-                            $isUserAdmin =auth()->user()->isAdmin() ||
-                                auth()->user()->isSuperAdmin();
+                            $isUserAdmin =
+                                auth()
+                                    ->user()
+                                    ->isAdmin() ||
+                                auth()
+                                    ->user()
+                                    ->isSuperAdmin();
                         @endphp
                         <option value="my-projects"
                             {{ request()->get('projects') == 'my-projects' || (!$isUserAdmin && !request()->has('projects')) ? 'selected' : '' }}>
@@ -95,31 +101,36 @@
                                 </td>
                             </tr>
                             @foreach ($client->projects as $project)
-                            <tr>
-                                <td class="w-33p">
-                                    <div class="pl-1 pl-xl-2">
-                                        @if ($project->getTotalToBeDeployedCount() > 0)
-                                            <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
-                                                  title="There is a requirement of {{ $project->getTotalToBeDeployedCount() }} team members">
-                                                <a href="{{ route('project.resource-requirement') }}"><i class="fa fa-users text-danger mr-0.5" aria-hidden="true"></i></a>
-                                            </span>
-                                        @endif
-                                        @can('projects.update')
-                                            <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
-                                        @else
-                                            @php
-                                            $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
-                                            @endphp
-                                            @if (in_array(auth()->user()->id, $team_member_ids))
-                                                <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
-                                            @else
-                                                <span class="pr-2 pr-xl-2">
-                                                    {{ $project->name }}
+                                <tr>
+                                    <td class="w-33p">
+                                        <div class="pl-1 pl-xl-2">
+                                            @if ($project->getTotalToBeDeployedCount() > 0)
+                                                <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
+                                                    title="There is a requirement of {{ $project->getTotalToBeDeployedCount() }} team members">
+                                                    <a href="{{ route('project.resource-requirement') }}"><i
+                                                            class="fa fa-users text-danger mr-0.5" aria-hidden="true"></i></a>
                                                 </span>
                                             @endif
-                                        @endcan
-                                    </div>
-                                </td>
+                                            @can('projects.update')
+                                                <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
+                                            @else
+                                                @php
+                                                    $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
+
+                                                    $keyAccountmanager = $project->getKeyAccountManagerAttribute();
+                                                    $userId = auth()->user()->id;
+                                                    $keyAccountmanagerId = $keyAccountmanager ? $keyAccountmanager->id : null;
+                                                @endphp
+                                                @if (in_array(auth()->user()->id, $team_member_ids) || $keyAccountmanagerId === $userId)
+                                                    <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
+                                                @else
+                                                    <span class="pr-2 pr-xl-2">
+                                                        {{ $project->name }}
+                                                    </span>
+                                                @endif
+                                            @endcan
+                                        </div>
+                                    </td>
                                     <td class="w-20p">
                                         @foreach ($project->getTeamMembers ?: [] as $teamMember)
                                             <span class="content tooltip-wrapper" data-html="true" data-toggle="tooltip"
@@ -147,12 +158,12 @@
                                             </span>
                                         @endforeach
                                     </td>
-                                    <td class="w-20p">  
-                                        <a class="{{$project->velocity_color_class}}"
-                                                    href="{{ route('project.effort-tracking', $project) }}"><i
-                                                        class="mr-0.5 fa fa-external-link-square"></i></a>
-                                                <span
-                                                    class="{{$project->velocity_color_class}} font-weight-bold">{{ $project->Velocity . ' (' . $project->current_hours_for_month . ' Hrs.)' }}</span> 
+                                    <td class="w-20p">
+                                        <a class="{{ $project->velocity_color_class }}"
+                                            href="{{ route('project.effort-tracking', $project) }}"><i
+                                                class="mr-0.5 fa fa-external-link-square"></i></a>
+                                        <span
+                                            class="{{ $project->velocity_color_class }} font-weight-bold">{{ $project->Velocity . ' (' . $project->current_hours_for_month . ' Hrs.)' }}</span>
                                     </td>
                                 </tr>
                             @endforeach

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -116,7 +116,7 @@
                                             @else
                                                 @php
                                                     $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
-                                                    $keyAccountmanager = $project->getKeyAccountManagerAttribute(); 
+                                                    $keyAccountmanager = $project->key_account_manager; 
                                                     $keyAccountmanagerId = $keyAccountmanager ? $keyAccountmanager->id : null;
                                                 @endphp
                                                 @if (in_array(auth()->user()->id, $team_member_ids) || auth()->user()->id === $keyAccountmanagerId)

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -116,11 +116,10 @@
                                             @else
                                                 @php
                                                     $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
-                                                    $keyAccountmanager = $project->getKeyAccountManagerAttribute();
-                                                    $userId = auth()->user()->id;
+                                                    $keyAccountmanager = $project->getKeyAccountManagerAttribute(); 
                                                     $keyAccountmanagerId = $keyAccountmanager ? $keyAccountmanager->id : null;
                                                 @endphp
-                                                @if (in_array(auth()->user()->id, $team_member_ids) || $keyAccountmanagerId === $userId)
+                                                @if (in_array(auth()->user()->id, $team_member_ids) || auth()->user()->id === $keyAccountmanagerId)
                                                     <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
                                                 @else
                                                     <span class="pr-2 pr-xl-2">

--- a/Modules/Project/Resources/views/index.blade.php
+++ b/Modules/Project/Resources/views/index.blade.php
@@ -115,13 +115,12 @@
                                                 <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
                                             @else
                                                 @php
-                                                    $team_member_ids = $project->getTeamMembers->pluck('team_member_id')->toArray();
-
+                                                    $teamMemberIds = $project->getTeamMembers->pluck('team_member_id')->toArray()
                                                     $keyAccountmanager = $project->getKeyAccountManagerAttribute();
                                                     $userId = auth()->user()->id;
                                                     $keyAccountmanagerId = $keyAccountmanager ? $keyAccountmanager->id : null;
                                                 @endphp
-                                                @if (in_array(auth()->user()->id, $team_member_ids) || $keyAccountmanagerId === $userId)
+                                                @if (in_array(auth()->user()->id, $teamMemberIds) || $keyAccountmanagerId === $userId)
                                                     <a href="{{ route('project.show', $project) }}">{{ $project->name }}</a>
                                                 @else
                                                     <span class="pr-2 pr-xl-2">


### PR DESCRIPTION
**Targets** #3149

### Description
The issue of inconsistent editing permissions for key account managers (KAMs) when their role is changed. Currently, when a user transitions from the role of a super admin , they lose the ability to edit the project entirely in which user is key account managers

### Changes Made:

- Reviewed the user role configuration and permission settings.
- Identified the specific areas where key account managers were restricted from editing the project.
- Conducted through testing to ensure the expected behavior is consistent across different scenarios

**Expected Time:**

- Issue Analysis and Understanding (0.5 - 1 hour)
- Implementing the Fix (1 - 2 hours)
- Testing and Verification (0.5 - 1 hour)

**Actual Time:**

- Issue Analysis and Understanding (0.5 - 1 hour): 2 hour
- Implementing the Fix (1 - 2 hours): 6 hour
- Testing and Verification (0.5 - 1 hour): 1hour

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
