### PR TITLE
issue/#3027/Books counts are not shown properly

### DIFF
--- a/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
@@ -26,11 +26,11 @@ class BookCategoryController extends Controller
         $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
         $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
-        return view('knowledgecafe.library.categories.index')
-        ->with('books', $books)
-        ->with('categories', $this->formatCategoryData($categories))
-        ->with('wishlistedBooksCount', $wishlistedBooksCount)
-        ->with('booksBorrowedCount', $booksBorrowedCount);
+        return view('knowledgecafe.library.categories.index', [
+        'books'=> $books,
+        'categories'=> $this->formatCategoryData($categories),
+        'wishlistedBooksCount'=> $wishlistedBooksCount,
+        'booksBorrowedCount'=> $booksBorrowedCount]);
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
@@ -23,10 +23,14 @@ class BookCategoryController extends Controller
     {
         $categories = BookCategory::withCount('books')->orderBy('name')->get();
         $books = Book::all();
+        $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
+        $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
         return view('knowledgecafe.library.categories.index')
         ->with('books', $books)
-        ->with('categories', $this->formatCategoryData($categories));
+        ->with('categories', $this->formatCategoryData($categories))
+        ->with('wishlistedBooksCount', $wishlistedBooksCount)
+        ->with('booksBorrowedCount', $booksBorrowedCount );
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
@@ -27,10 +27,11 @@ class BookCategoryController extends Controller
         $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
         return view('knowledgecafe.library.categories.index', [
-        'books'=> $books,
-        'categories'=> $this->formatCategoryData($categories),
-        'wishlistedBooksCount'=> $wishlistedBooksCount,
-        'booksBorrowedCount'=> $booksBorrowedCount]);
+            'books' => $books,
+            'categories' => $this->formatCategoryData($categories),
+            'wishlistedBooksCount' => $wishlistedBooksCount,
+            'booksBorrowedCount' => $booksBorrowedCount
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookCategoryController.php
@@ -30,7 +30,7 @@ class BookCategoryController extends Controller
         ->with('books', $books)
         ->with('categories', $this->formatCategoryData($categories))
         ->with('wishlistedBooksCount', $wishlistedBooksCount)
-        ->with('booksBorrowedCount', $booksBorrowedCount );
+        ->with('booksBorrowedCount', $booksBorrowedCount);
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -46,7 +46,7 @@ class BookController extends Controller
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');
-        
+
         return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories'));
     }
 

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -333,10 +333,10 @@ class BookController extends Controller
         $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
         $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
-        return view('knowledgecafe.library.books.book-a-month')
-        ->with('booksCollection', $booksCollection)
-        ->with('books', $books)
-        ->with('wishlistedBooksCount', $wishlistedBooksCount)
-        ->with('booksBorrowedCount', $booksBorrowedCount);
+        return view('knowledgecafe.library.books.book-a-month', [
+        'booksCollection'=> $booksCollection,
+        'books'=> $books,
+        'wishlistedBooksCount'=> $wishlistedBooksCount,
+        'booksBorrowedCount'=> $booksBorrowedCount]);
     }
 }

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -45,7 +45,6 @@ class BookController extends Controller
             default:
                 $books = Book::getList($searchString);
         }
-        
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -46,10 +46,8 @@ class BookController extends Controller
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');
-        $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
-        $booksBorrowerCount = auth()->user()->booksBorrower->count();
-
-        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount', 'booksBorrowerCount'));
+        
+        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories'));
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -29,7 +29,6 @@ class BookController extends Controller
         $searchCategory = $request->category_name ?? false;
         $searchString = (request()->has('search')) ? request()->input('search') : false;
         $categories = BookCategory::orderBy('name')->get();
-
         $wishlistedBooks = auth()->user()->booksInWishlist;
         $booksBorrower = auth()->user()->booksBorrower;
         switch (request()) {
@@ -50,6 +49,7 @@ class BookController extends Controller
         $books->load('borrowers');
         $wishlistedBooksCount = $wishlistedBooks->count();
         $booksBorrowerCount = $booksBorrower->count();
+        
         return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount','booksBorrowerCount'));
     }
 

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -149,7 +149,7 @@ class BookController extends Controller
             $ISBN = $validated['isbn'];
         }
 
-        if (! $ISBN || strlen($ISBN) < 13) {
+        if (!$ISBN || strlen($ISBN) < 13) {
             return response()->json([
                 'error' => true,
                 'message' => 'Invalid ISBN : ' . $ISBN,
@@ -167,7 +167,7 @@ class BookController extends Controller
 
         $book = BookServices::getBookDetails($ISBN);
 
-        if (! isset($book['items'])) {
+        if (!isset($book['items'])) {
             return response()->json([
                 'error' => true,
                 'message' => 'Invalid ISBN : ' . $ISBN,
@@ -239,8 +239,8 @@ class BookController extends Controller
     public function getBooksCount()
     {
         $books = (request()->has('cat')) ?
-        Book::getByCategoryName(request()->input('cat'))->count() :
-        Book::count();
+            Book::getByCategoryName(request()->input('cat'))->count() :
+            Book::count();
 
         return $books;
     }
@@ -253,8 +253,8 @@ class BookController extends Controller
             $pageNumber = 1;
         }
         $books = (request()->has('cat')) ?
-        Book::getByCategoryName(request()->input('cat')) :
-        Book::with(['categories'])->orderBy('title')->skip(($pageNumber - 1) * 50)->take(50)->get();
+            Book::getByCategoryName(request()->input('cat')) :
+            Book::with(['categories'])->orderBy('title')->skip(($pageNumber - 1) * 50)->take(50)->get();
 
         $data = [];
         foreach ($books as $index => $book) {
@@ -334,9 +334,10 @@ class BookController extends Controller
         $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
         return view('knowledgecafe.library.books.book-a-month', [
-        'booksCollection'=> $booksCollection,
-        'books'=> $books,
-        'wishlistedBooksCount'=> $wishlistedBooksCount,
-        'booksBorrowedCount'=> $booksBorrowedCount]);
+            'booksCollection' => $booksCollection,
+            'books' => $books,
+            'wishlistedBooksCount' => $wishlistedBooksCount,
+            'booksBorrowedCount' => $booksBorrowedCount
+        ]);
     }
 }

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -46,8 +46,11 @@ class BookController extends Controller
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');
+        $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
+        $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
-        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories'));
+
+        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount', 'booksBorrowedCount'));
     }
 
     /**
@@ -328,7 +331,13 @@ class BookController extends Controller
                     return Carbon::parse($item->created_at)->format('n');
                 }, 'desc');
             });
+        $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
+        $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
-        return view('knowledgecafe.library.books.book-a-month')->with('booksCollection', $booksCollection)->with('books', $books);
+        return view('knowledgecafe.library.books.book-a-month')
+        ->with('booksCollection', $booksCollection)
+        ->with('books', $books)
+        ->with('wishlistedBooksCount', $wishlistedBooksCount)
+        ->with('booksBorrowedCount', $booksBorrowedCount);
     }
 }

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -49,7 +49,6 @@ class BookController extends Controller
         $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
         $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
-
         return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount', 'booksBorrowedCount'));
     }
 

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -31,6 +31,7 @@ class BookController extends Controller
         $categories = BookCategory::orderBy('name')->get();
         $wishlistedBooks = auth()->user()->booksInWishlist;
         $booksBorrower = auth()->user()->booksBorrower;
+
         switch (request()) {
             case request()->has('wishlist'):
                 $books = $wishlistedBooks;
@@ -44,6 +45,7 @@ class BookController extends Controller
             default:
                 $books = Book::getList($searchString);
         }
+        
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -50,8 +50,7 @@ class BookController extends Controller
         $wishlistedBooksCount = $wishlistedBooks->count();
         $booksBorrowerCount = $booksBorrower->count();
 
-    
-        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount','booksBorrowerCount'));
+        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount', 'booksBorrowerCount'));
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -50,7 +50,6 @@ class BookController extends Controller
         $books->load('borrowers');
         $wishlistedBooksCount = $wishlistedBooks->count();
         $booksBorrowerCount = $booksBorrower->count();
-
         return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount','booksBorrowerCount'));
     }
 

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -29,15 +29,13 @@ class BookController extends Controller
         $searchCategory = $request->category_name ?? false;
         $searchString = (request()->has('search')) ? request()->input('search') : false;
         $categories = BookCategory::orderBy('name')->get();
-        $wishlistedBooks = auth()->user()->booksInWishlist;
-        $booksBorrower = auth()->user()->booksBorrower;
 
         switch (request()) {
             case request()->has('wishlist'):
-                $books = $wishlistedBooks;
+                $books = auth()->user()->booksInWishlist;
                 break;
             case request()->has('borrowedBook'):
-                $books = $booksBorrower;
+                $books = auth()->user()->booksBorrower;
                 break;
             case request()->has('categoryName'):
                 $books = Book::getByCategoryName($searchCategory);
@@ -48,8 +46,8 @@ class BookController extends Controller
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');
-        $wishlistedBooksCount = $wishlistedBooks->count();
-        $booksBorrowerCount = $booksBorrower->count();
+        $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
+        $booksBorrowerCount = auth()->user()->booksBorrower->count();
 
         return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount', 'booksBorrowerCount'));
     }

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -149,7 +149,7 @@ class BookController extends Controller
             $ISBN = $validated['isbn'];
         }
 
-        if (!$ISBN || strlen($ISBN) < 13) {
+        if (! $ISBN || strlen($ISBN) < 13) {
             return response()->json([
                 'error' => true,
                 'message' => 'Invalid ISBN : ' . $ISBN,
@@ -167,7 +167,7 @@ class BookController extends Controller
 
         $book = BookServices::getBookDetails($ISBN);
 
-        if (!isset($book['items'])) {
+        if (! isset($book['items'])) {
             return response()->json([
                 'error' => true,
                 'message' => 'Invalid ISBN : ' . $ISBN,

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -30,12 +30,14 @@ class BookController extends Controller
         $searchString = (request()->has('search')) ? request()->input('search') : false;
         $categories = BookCategory::orderBy('name')->get();
 
+        $wishlistedBooks = auth()->user()->booksInWishlist;
+        $booksBorrower = auth()->user()->booksBorrower;
         switch (request()) {
             case request()->has('wishlist'):
-                $books = auth()->user()->booksInWishlist;
+                $books = $wishlistedBooks;
                 break;
             case request()->has('borrowedBook'):
-                $books = auth()->user()->booksBorrower;
+                $books = $booksBorrower;
                 break;
             case request()->has('categoryName'):
                 $books = Book::getByCategoryName($searchCategory);
@@ -46,8 +48,10 @@ class BookController extends Controller
         $loggedInUser = auth()->user();
         $books->load('wishers');
         $books->load('borrowers');
+        $wishlistedBooksCount = $wishlistedBooks->count();
+        $booksBorrowerCount = $booksBorrower->count();
 
-        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories'));
+        return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount','booksBorrowerCount'));
     }
 
     /**

--- a/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
+++ b/app/Http/Controllers/KnowledgeCafe/Library/BookController.php
@@ -49,7 +49,8 @@ class BookController extends Controller
         $books->load('borrowers');
         $wishlistedBooksCount = $wishlistedBooks->count();
         $booksBorrowerCount = $booksBorrower->count();
-        
+
+    
         return view('knowledgecafe.library.books.index', compact('books', 'loggedInUser', 'categories', 'wishlistedBooksCount','booksBorrowerCount'));
     }
 

--- a/app/Models/KnowledgeCafe/Library/Book.php
+++ b/app/Models/KnowledgeCafe/Library/Book.php
@@ -49,7 +49,7 @@ class Book extends Model
 
     public static function getByCategoryName($categoryName)
     {
-        if (!$categoryName) {
+        if (! $categoryName) {
             return false;
         }
 

--- a/app/Models/KnowledgeCafe/Library/Book.php
+++ b/app/Models/KnowledgeCafe/Library/Book.php
@@ -49,7 +49,7 @@ class Book extends Model
 
     public static function getByCategoryName($categoryName)
     {
-        if (! $categoryName) {
+        if (!$categoryName) {
             return false;
         }
 

--- a/resources/views/knowledgecafe/library/menu.blade.php
+++ b/resources/views/knowledgecafe/library/menu.blade.php
@@ -23,15 +23,13 @@
     <li class="nav-item">
         @php
          $params = array_merge($request,  ['wishlist' => 'booksInWishlist']);
-         $books = auth()->user()->booksInWishlist->count();
         @endphp
-        <a class="nav-item nav-link  {{ (request()->input('wishlist','active') === 'booksInWishlist') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Wish listed Books({{$books}})</a>
+        <a class="nav-item nav-link  {{ (request()->input('wishlist','active') === 'booksInWishlist') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Wish listed Books({{$wishlistedBooksCount}})</a>
     </li>
     <li class="nav-item">
         @php
           $params = array_merge($request,  ['borrowedBook' => 'markedAsBorrowed']);
-          $books = auth()->user()->booksBorrower->count();
         @endphp
-        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{$books}})</a>
+        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{ $booksBorrowerCount}})</a>
     </li>
 </ul>

--- a/resources/views/knowledgecafe/library/menu.blade.php
+++ b/resources/views/knowledgecafe/library/menu.blade.php
@@ -7,9 +7,10 @@
 
      $allBooksSelected =  $active === 'books' && ! $wishlistSelected && ! $borrowedSelected;
      $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
-     $booksBorrowerCount = auth()->user()->booksBorrower->count();
+     $booksBorrowedCount = auth()->user()->booksBorrower->count();
 
     @endphp
+    <li>
         <a class="nav-item nav-link {{ $allBooksSelected ? 'active' : '' }}"  href="{{ route('books.index', $request) }}"><i class="fa fa-book"></i>&nbsp;Books</a>
     </li>
 
@@ -32,6 +33,6 @@
         @php
           $params = array_merge($request,  ['borrowedBook' => 'markedAsBorrowed']);
         @endphp
-        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{ $booksBorrowerCount}})</a>
+        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{ $booksBorrowedCount}})</a>
     </li>
 </ul>

--- a/resources/views/knowledgecafe/library/menu.blade.php
+++ b/resources/views/knowledgecafe/library/menu.blade.php
@@ -6,6 +6,8 @@
      $borrowedSelected = request()->input('borrowedBook','active') === 'markedAsBorrowed';
 
      $allBooksSelected =  $active === 'books' && ! $wishlistSelected && ! $borrowedSelected;
+     $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
+     $booksBorrowerCount = auth()->user()->booksBorrower->count();
 
     @endphp
         <a class="nav-item nav-link {{ $allBooksSelected ? 'active' : '' }}"  href="{{ route('books.index', $request) }}"><i class="fa fa-book"></i>&nbsp;Books</a>

--- a/resources/views/knowledgecafe/library/menu.blade.php
+++ b/resources/views/knowledgecafe/library/menu.blade.php
@@ -23,15 +23,15 @@
     <li class="nav-item">
         @php
          $params = array_merge($request,  ['wishlist' => 'booksInWishlist']);
-         $wishlistCount = auth()->user()->booksInWishlist->count();
+         $books = auth()->user()->booksInWishlist->count();
         @endphp
-        <a class="nav-item nav-link  {{ (request()->input('wishlist','active') === 'booksInWishlist') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Wish listed Books({{$wishlistCount}})</a>
+        <a class="nav-item nav-link  {{ (request()->input('wishlist','active') === 'booksInWishlist') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Wish listed Books({{$books}})</a>
     </li>
     <li class="nav-item">
         @php
           $params = array_merge($request,  ['borrowedBook' => 'markedAsBorrowed']);
-          $borrowedCount = auth()->user()->booksBorrower->count();
+          $books = auth()->user()->booksBorrower->count();
         @endphp
-        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{$borrowedCount}})</a>
+        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{$books}})</a>
     </li>
 </ul>

--- a/resources/views/knowledgecafe/library/menu.blade.php
+++ b/resources/views/knowledgecafe/library/menu.blade.php
@@ -23,13 +23,15 @@
     <li class="nav-item">
         @php
          $params = array_merge($request,  ['wishlist' => 'booksInWishlist']);
+         $wishlistCount = auth()->user()->booksInWishlist->count();
         @endphp
-        <a class="nav-item nav-link  {{ (request()->input('wishlist','active') === 'booksInWishlist') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Wish listed Books({{$books->load('wishers')->count()}})</a>
+        <a class="nav-item nav-link  {{ (request()->input('wishlist','active') === 'booksInWishlist') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Wish listed Books({{$wishlistCount}})</a>
     </li>
     <li class="nav-item">
         @php
           $params = array_merge($request,  ['borrowedBook' => 'markedAsBorrowed']);
+          $borrowedCount = auth()->user()->booksBorrower->count();
         @endphp
-        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{$books->load('borrowers')->count()}})</a>
+        <a class="nav-item nav-link {{ (request()->input('borrowedBook','active') === 'markedAsBorrowed') ? 'active' : '' }}"  href="{{ route('books.index', $params)  }}"><i class="fa fa-book"></i>&nbsp;Borrowed Books({{$borrowedCount}})</a>
     </li>
 </ul>

--- a/resources/views/knowledgecafe/library/menu.blade.php
+++ b/resources/views/knowledgecafe/library/menu.blade.php
@@ -6,9 +6,6 @@
      $borrowedSelected = request()->input('borrowedBook','active') === 'markedAsBorrowed';
 
      $allBooksSelected =  $active === 'books' && ! $wishlistSelected && ! $borrowedSelected;
-     $wishlistedBooksCount = auth()->user()->booksInWishlist->count();
-     $booksBorrowedCount = auth()->user()->booksBorrower->count();
-
     @endphp
     <li>
         <a class="nav-item nav-link {{ $allBooksSelected ? 'active' : '' }}"  href="{{ route('books.index', $request) }}"><i class="fa fa-book"></i>&nbsp;Books</a>


### PR DESCRIPTION
Targets #3027 


### Description
I have found the total numbers of books shown in the Wishlist's menu & Borrowed Books menu.

I have added to lines in    resources\views\knowledgecafe\library\menu.blade.php

  $wishlistCount = auth()->user()->booksInWishlist->count();
 $borrowedCount = auth()->user()->booksBorrower->count();

### Checklist:
First i checked the flow of code then apply changes to menu.blade.php
![books](https://github.com/ColoredCow/portal/assets/121542707/20550daa-2ac2-4444-a0f4-95792a6f0c20)
![wishlist](https://github.com/ColoredCow/portal/assets/121542707/2a9676ed-f171-4e64-b811-f7ae6b17e816)
![borrowed](https://github.com/ColoredCow/portal/assets/121542707/6be8fea8-32fd-427b-a43f-e652c5bb5085)

