### PR TITLE
#3164 Remove the inactive team members and inactive or halted projects from email notification

### DIFF
--- a/Modules/Project/Services/ProjectService.php
+++ b/Modules/Project/Services/ProjectService.php
@@ -373,7 +373,7 @@ class ProjectService implements ProjectServiceContract
 
     public function getMailDetailsForKeyAccountManagers()
     {
-        $zeroEffortProject = ProjectTeamMember::where('daily_expected_effort', 0)->get('project_id');
+        $zeroEffortProject = ProjectTeamMember::where('daily_expected_effort', 0)->whereNull('ended_on')->get('project_id');
         $projects = Project::whereIn('id', $zeroEffortProject)->where('status', 'active')->get();
         $keyAccountManagersDetails = [];
         foreach ($projects as $project) {

--- a/Modules/Project/Services/ProjectService.php
+++ b/Modules/Project/Services/ProjectService.php
@@ -374,7 +374,7 @@ class ProjectService implements ProjectServiceContract
     public function getMailDetailsForKeyAccountManagers()
     {
         $zeroEffortProject = ProjectTeamMember::where('daily_expected_effort', 0)->get('project_id');
-        $projects = Project::whereIn('id', $zeroEffortProject)->get();
+        $projects = Project::whereIn('id', $zeroEffortProject)->where('status', 'active')->get();
         $keyAccountManagersDetails = [];
         foreach ($projects as $project) {
             $user = $project->client->keyAccountManager;


### PR DESCRIPTION
## Targets #3164
 
### Description
The cron job will only send email notifications to the key account manager for active projects and team members. The filtering mechanism will exclude inactive team members and inactive or halted projects from receiving email notifications.

## Expected Time
- [x] Set up the mail trap for email. `1-2 hours`
- [x] Understand the e-mail flow in Laravel. `2-3 hours`
- [x] Understand the bug. `3-4 hours`
- [x] For testing, code review, and documentation. `1-2 hours`

## Actual Time 
- [x] Set up the mail trap for email. `1-2 hours`
- [x] Understand the e-mail flow in Laravel. `3-4 hours`
- [x] Understand the bug. `4-5 hours`
- [x] For testing, code review, and documentation. `1-2 hours`
---
### TOTAL TIME = 13 HOURS
---

## Unit testing
- Understand the email flow and cron job schedule in Laravel [link](https://www.itsolutionstuff.com/post/laravel-send-scheduled-emails-tutorialexample.html)


### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.