### PR TITLE
Fixed the bug for employee working staff

### DIFF
--- a/Modules/HR/Http/Controllers/EmployeeController.php
+++ b/Modules/HR/Http/Controllers/EmployeeController.php
@@ -2,14 +2,14 @@
 
 namespace Modules\HR\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Services\EmployeeService;
-use Modules\HR\Entities\Employee;
-use Illuminate\Routing\Controller;
-use Modules\HR\Entities\HrJobDomain;
-use Modules\HR\Entities\HrJobDesignation;
-use Modules\HR\Entities\Job;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\HR\Entities\Employee;
+use Modules\HR\Entities\HrJobDesignation;
+use Modules\HR\Entities\HrJobDomain;
+use Modules\HR\Entities\Job;
 use Modules\Project\Entities\ProjectTeamMember;
 
 class EmployeeController extends Controller
@@ -36,9 +36,9 @@ class EmployeeController extends Controller
         $filters = $filters ?: $this->service->defaultFilters();
         $name = request('name');
         $employeeData = Employee::where('staff_type', $name)
+            ->applyFilters($filters)
             ->leftJoin('project_team_members', 'employees.user_id', '=', 'project_team_members.team_member_id')
             ->selectRaw('employees.*, team_member_id, count(team_member_id) as project_count')
-            ->whereNull('project_team_members.ended_on')
             ->groupBy('employees.user_id')
             ->orderby('project_count', 'desc')
             ->get();
@@ -84,7 +84,7 @@ class EmployeeController extends Controller
         return view('hr.employees.fte-handler')->with([
             'domainName' => $domainName,
             'employees' => $employees,
-            'jobName' => $jobName
+            'jobName' => $jobName,
         ]);
     }
 


### PR DESCRIPTION
Targets #3178

### Description:

Super admins were unable to change the working staff type for certain users. The existing functionality has been modified to ensure that the working staff type can be successfully updated for all users.

### Changes Made:

The Employee query was updated to include additional filters and modifications to ensure that all users, regardless of their existing working staff type, can be accessed and modified by super admins.

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
