### PR TITLE
fix the media close button alignment issue 

### DIFF
--- a/Modules/Media/Resources/views/media/index.blade.php
+++ b/Modules/Media/Resources/views/media/index.blade.php
@@ -19,38 +19,38 @@
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <div class="modal-body p-0 pb-4">
-                                    <div class="card-header bg-secondary d-flex justify-content-between">
-                                        <h3 class="text-light fw-bold">Add New Post</h3>
-                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                            <span aria-hidden="true">&times;</span>
-                                        </button>
-                                    </div>
-                                    <div class="card-body p-4">
-                                        <form action="{{ route('media.index') }}" method="POST" enctype="multipart/form-data">
-                                            @csrf
-                                            <div class="my-2"><h3 class="text-secondary">Event Name</h3>
-                                                <input type="text" name="event_name" id="event_name" class="form-control @error('event_name') is-invalid @enderror" placeholder="Event_name" value="{{ old('event_name') }}">
-                                                @error('event_name')
-                                                    <div class="invalid-feedback">{{ $message }}</div>
-                                                @enderror
-                                            </div>
-                                            <div class="my-2"><h3 class="text-secondary">File Upload</h3>
-                                                <input type="file" name="file" id="file" accept="image/*" class="form-control @error('file') is-invalid @enderror">
-                                                @error('file')
-                                                    <div class="invalid-feedback">{{ $message }}</div>
-                                                @enderror
-                                            </div>
-                                            <div class="my-2"><h3 class="text-secondary">Description</h3>
-                                                <textarea name="description" id="description" rows="6" class="form-control @error('description') is-invalid @enderror" placeholder="Description">{{ old('description') }}</textarea>
-                                                @error('description')
-                                                    <div class="invalid-feedback">{{ $message }}</div>
-                                                @enderror
-                                            </div>
-                                            <div class="my-2">
-                                                <input type="submit" value="Add Post" class="btn btn-success float-right">
-                                            </div>
-                                        </form>
-                                    </div>
+                        <div class="card-header bg-secondary d-flex justify-content-between">
+                            <h3 class="text-light fw-bold">Add New Post</h3>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="card-body p-4">
+                            <form action="{{ route('media.index') }}" method="POST" enctype="multipart/form-data">
+                                @csrf
+                                <div class="my-2"><h3 class="text-secondary">Event Name</h3>
+                                    <input type="text" name="event_name" id="event_name" class="form-control @error('event_name') is-invalid @enderror" placeholder="Event_name" value="{{ old('event_name') }}">
+                                    @error('event_name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="my-2"><h3 class="text-secondary">File Upload</h3>
+                                    <input type="file" name="file" id="file" accept="image/*" class="form-control @error('file') is-invalid @enderror">
+                                    @error('file')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="my-2"><h3 class="text-secondary">Description</h3>
+                                    <textarea name="description" id="description" rows="6" class="form-control @error('description') is-invalid @enderror" placeholder="Description">{{ old('description') }}</textarea>
+                                    @error('description')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="my-2">
+                                    <input type="submit" value="Add Post" class="btn btn-success float-right">
+                                </div>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/Modules/Media/Resources/views/media/index.blade.php
+++ b/Modules/Media/Resources/views/media/index.blade.php
@@ -18,17 +18,12 @@
         <div class="modal fade" id="photoGallery" tabindex="-1" role="dialog" aria-labelledby="photoGalleryLabel" aria-hidden="true">
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="row my-3">
-                            <div class="col-lg-20 mx-auto">
-                                <div class="card shadow">
-                                    <div class="card-header bg-secondary">
+                    <div class="modal-body p-0 pb-4">
+                                    <div class="card-header bg-secondary d-flex justify-content-between">
                                         <h3 class="text-light fw-bold">Add New Post</h3>
+                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                            <span aria-hidden="true">&times;</span>
+                                        </button>
                                     </div>
                                     <div class="card-body p-4">
                                         <form action="{{ route('media.index') }}" method="POST" enctype="multipart/form-data">
@@ -56,9 +51,6 @@
                                             </div>
                                         </form>
                                     </div>
-                                </div>
-                            </div> 
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Targets #3183 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->

<!--- Please complete the following steps and check these boxes before filing your PR: -->

### Description
<!--- Describe your changes in detail -->
I have done the changes to the close button which is now on the same level as Add New Post heading.
After that, I remove the top blank card and the outer card. 


Before changes:
<img width="1228" alt="Screenshot 2023-06-22 at 12 57 05 PM" src="https://github.com/ColoredCow/portal/assets/104312137/e61e0d50-0555-4776-b34d-001e590d75af">


Here is the screenshot after the changes:
<img width="1274" alt="Screenshot 2023-06-22 at 2 58 00 PM" src="https://github.com/ColoredCow/portal/assets/104312137/1ed3ebc5-4cbb-4884-b8e6-0c9bbc1a9225">


<!--- Why these changes are required? What existing problem does the pull request solve? -->
### Estimated Time
- Align the close button  to the same level as Add New Post heading.        **30 min**
-  Remove the top blank card  and the outer card.        **1-2 Hour**
- For testing and code review .     **2-3 hours** 

### Actual Time
-  Align the close button  to the same level as Add New Post heading.      **10 min**
-   Remove the top blank card  and the outer card.      **30min**
-  For testing and code review.      **2hour** 

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-  I have performed a self-review of my own code.