### PR TITLE
#2823 Show Project Velocity in dashboard 

### DIFF
--- a/Modules/Project/Entities/Project.php
+++ b/Modules/Project/Entities/Project.php
@@ -28,6 +28,8 @@ class Project extends Model implements Auditable
 
     protected $dates = ['start_date', 'end_date'];
 
+    protected $appends = ['velocity', 'current_hours_for_month', 'velocity_color_class'];
+
     protected static function newFactory()
     {
         return new ProjectFactory();

--- a/resources/js/components/Dashboard/UserDashboardProjects.vue
+++ b/resources/js/components/Dashboard/UserDashboardProjects.vue
@@ -9,9 +9,14 @@
                 <div v-if="this.projects.length > 0" class="list list-group unstyled-list">
                     <div v-for="(project, index) in this.projects" :key="index">
                         <div class="row" >
-                            <div class="col-9 text-left d-flex align-items-center">
-                                <div class="w-250">
+                            <div class="col-12 text-left d-flex align-items-center">
+                                <div class="w-300">
                                     <a :href="'/projects/'+project.id+'/show/'">{{ project.name }}</a>
+                                    <span :class="project.velocity_color_class + ' font-weight-bold' + ' ml-2'">
+                                    <a :href="'/projects/'+project.id+'/show/'" class="text-danger">
+                                    <i class="mr-0.5 fa fa-external-link-square"></i>
+                                    </a> 
+                                    {{ project.velocity + ' (' + project.current_hours_for_month + ' Hrs.)' }} </span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Targets #2823 
 
### Description
Several changes were made to enhance the user Dashboard functionality, currently, it does not show the velocity of the user, next to my projects in the Coloredcow portal. The total velocity along with the hours booked will help the user to keep track of the velocity. 

## Approach
Checked the Project index page as velocity was passed there, went through the controller, service page, and found out that the velocity function was not defined it is an accessor and its attribute was defined in the entity. So check how I can use this attribute on the vue page of the user dashboard. Used appends as data was not getting passed from the database. Then used the attribute on vue page by making several changes. 

## Expected Time
- [x] Code review and documentation: 0.5-1 hour.
- [x] Understanding the functionality: 1-2 hours.
- [x] Making the required changes: 2-3 hours.
- [x] Testing, code, review, and documentation: 1 hour.

### TOTAL TIME = 6-8 Hours.

## Actual Time 
- [x] Code review and documentation: 0.5-1 hour.
- [x] Understanding the functionality and use of accessors: 5 hours.
Making the required changes: 2-3 hours.
Testing, code, review, and documentation: 1 hour.

### TOTAL TIME = 10 Hours.
---

## Accessors-
https://laravel.com/docs/5.2/eloquent-mutators#accessors-and-mutators


### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.