### PR TITLE
fix: column name in codetrek module

### DIFF
--- a/Modules/CodeTrek/Resources/views/index.blade.php
+++ b/Modules/CodeTrek/Resources/views/index.blade.php
@@ -97,7 +97,7 @@
                         <tr class="text-center sticky-top">
                             <th class="col-md-4">Name</th>
                             <th class="col-md-2">Days in CodeTrek</th>
-                            <th>Status</th>
+                            <th>Level</th>
                             <th>Feedbacks</th>
                         </tr>
                     </thead>


### PR DESCRIPTION
Targets #3187 


### Description
Fix Column name from `Status` to `Level` in CodeTrek Module.
