### PR TITLE
#3195 Featrue: Added sort functionality in codetrek candidates page

### DIFF
--- a/Modules/CodeTrek/Resources/views/index.blade.php
+++ b/Modules/CodeTrek/Resources/views/index.blade.php
@@ -90,6 +90,19 @@
                         Completed({{$statusCounts['completed']}})</a>
                 </li>
             </div>
+            <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="sortDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Sort by
+                </button>
+                <div class="dropdown-menu " aria-labelledby="sortDropdown" style="z-index: 9999;">
+                    <a class="dropdown-item " href="{{route('codetrek.index',['order' => 'name'])}}">
+                        <span class="font-weight-bold">Name</span>
+                    </a> 
+                    <a class="dropdown-item" href="{{route('codetrek.index',['order' => 'date'])}}">
+                        <span class="font-weight-bold ">Date</span>
+                    </a>
+                </div>
+            </div>
         </ul>
         @if (request()->input('tab', 'active') == 'active' || request()->tab == 'applicants')
             <div>

--- a/Modules/CodeTrek/Resources/views/index.blade.php
+++ b/Modules/CodeTrek/Resources/views/index.blade.php
@@ -90,19 +90,24 @@
                         Completed({{$statusCounts['completed']}})</a>
                 </li>
             </div>
-            <div class="dropdown">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="sortDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Sort by
-                </button>
-                <div class="dropdown-menu " aria-labelledby="sortDropdown" style="z-index: 9999;">
-                    <a class="dropdown-item " href="{{route('codetrek.index',['order' => 'name'])}}">
-                        <span class="font-weight-bold">Name</span>
-                    </a> 
-                    <a class="dropdown-item" href="{{route('codetrek.index',['order' => 'date'])}}">
-                        <span class="font-weight-bold ">Date</span>
-                    </a>
+            <form action="{{ route('codetrek.index') }}" id="sortingForm">
+                <div class="form-group w-120">
+                    <select class="form-control bg-light" name="order" id="order" onchange="document.getElementById('sortingForm').submit();">
+                        <option value="">
+                            Sort By
+                        </option>
+                        <option value="name"  {{ request()->get('order') == 'name' ? 'selected' : ''}}>
+                            Name
+                        </option>
+                        <option value="date" {{ request()->get('order') == 'date' ? 'selected' : ''}}>
+                            Date
+                        </option>
+                    </select>
+                    <input type="hidden" name="status" value="{{ $request['status'] ?? '' }}">
+                    <input type="hidden" name="centre" value="{{ $request['centre'] ?? '' }}">
+                    <input type="hidden" name="name" value="{{ request()->get('name') }}">
                 </div>
-            </div>
+            </form>
         </ul>
         @if (request()->input('tab', 'active') == 'active' || request()->tab == 'applicants')
             <div>

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -21,7 +21,7 @@ class CodeTrekService
         if ($centre) {
             $applicants = $query->where('centre_id', $centre);
         }
-        if ($sort == "date") {
+        if ($sort == 'date') {
             $applicants = $query->orderBy('start_date', 'desc');
         } else {
             $applicants = $query->orderBy('first_name');

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -17,7 +17,7 @@ class CodeTrekService
         $sort = $data['order'] ?? null;
         $query = CodeTrekApplicant::where('status', $status);
         $applicants = null;
-       
+
         if ($centre) {
             $applicants = $query->where('centre_id', $centre);
         }

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -14,7 +14,7 @@ class CodeTrekService
         $search = $data['name'] ?? null;
         $status = $data['status'] ?? 'active';
         $centre = $data['centre'] ?? null;
-        $sort = $data["order"] ?? null;
+        $sort = $data['order'] ?? null;
         $query = CodeTrekApplicant::where('status', $status);
         $applicants = null;
        

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -22,8 +22,8 @@ class CodeTrekService
             $applicants = $query->where('centre_id', $centre);
         }
         if ($sort == "date") {
-            $applicants = $query->orderBy('start_date','desc');
-        } else{
+            $applicants = $query->orderBy('start_date', 'desc');
+        } else {
             $applicants = $query->orderBy('first_name');
         }
         $applicants = $query->when($search, function ($query) use ($search) {

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -14,10 +14,17 @@ class CodeTrekService
         $search = $data['name'] ?? null;
         $status = $data['status'] ?? 'active';
         $centre = $data['centre'] ?? null;
-        $query = CodeTrekApplicant::where('status', $status)->orderBy('first_name');
+        $sort = $data["order"] ?? null;
+        $query = CodeTrekApplicant::where('status', $status); 
         $applicants = null;
+       
         if ($centre) {
             $applicants = $query->where('centre_id', $centre);
+        }
+        if ($sort == "date") {
+            $applicants = $query->orderBy('start_date','desc');
+        } else{
+             $applicants = $query->orderBy('first_name');
         }
         $applicants = $query->when($search, function ($query) use ($search) {
             return $query->whereRaw("CONCAT(first_name, ' ', last_name) LIKE '%$search%'");

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -15,7 +15,7 @@ class CodeTrekService
         $status = $data['status'] ?? 'active';
         $centre = $data['centre'] ?? null;
         $sort = $data["order"] ?? null;
-        $query = CodeTrekApplicant::where('status', $status); 
+        $query = CodeTrekApplicant::where('status', $status);
         $applicants = null;
        
         if ($centre) {
@@ -24,7 +24,7 @@ class CodeTrekService
         if ($sort == "date") {
             $applicants = $query->orderBy('start_date','desc');
         } else{
-             $applicants = $query->orderBy('first_name');
+            $applicants = $query->orderBy('first_name');
         }
         $applicants = $query->when($search, function ($query) use ($search) {
             return $query->whereRaw("CONCAT(first_name, ' ', last_name) LIKE '%$search%'");


### PR DESCRIPTION
Targets #3195 
### Description
In the Codetrek module, the candidate list is currently sorted by name which sometimes create issues when we add a new candidate and he/she gets added to the list at some random position based on alphabetical order.

Therfore, I developed a dropdown menu that presents two sorting options: one based on the candidate's name and the other based on their most recent joining date at CodeTrek. 
This will provide a good user experience for those who wish to view both new candidates and candidates in alphabetical order.

### Approach
My approach involved gaining a thorough understanding of the system. I proceeded by adding a 'Sort By' dropdown menu to the "codetrek "applicant .Passes the parameter to the codetrek.index route .Create a functionality in CodetrekService for sorting. 


**After implementing the code the CodeTrek looks like this**
![Screenshot 2023-07-03 174413](https://github.com/ColoredCow/portal/assets/104312137/b3bc9ee5-1975-43b7-9098-e9382619c6b7)

### Description
<!--- Describe your changes in detail -->
<!--- Why these changes are required? What existing problem does the pull request solve? -->

**Expected Time**

- [x] System and Process Understanding. `1-2 Hour`
- [x] Create a dropdown menu "Order BY" to toggle between name and date. `0-1 Hour`
- [x] Create a route for toggle . `1-2 Hour`
- [x] Create a function in CodetrekController for sorting. `2-3 Hour`
- [x] Display the changes in blade file. `2-3 Hour`

**Total Time : 10-11 Hours**

**Actual Time**

- [x] System and Process Understanding. `1-2 Hour`
- [x] Create a dropdown menu "Order BY" to toggle between name and date. `0-1 Hour`
- [x] Passes the parameter to the codetrek.index route  . `1-2 Hour`
- [x] Create a functionality in CodetrekService for sorting. `3-4 Hour`
- [x] Verify if the functionality is operational or not.. `0-1 Hour`

**Total Time : 10 Hours**
### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
