### PR TITLE
#3253 Missing Domain Dropdown in "Add New Participant" Form

### DIFF
--- a/Modules/CodeTrek/Config/config.php
+++ b/Modules/CodeTrek/Config/config.php
@@ -42,5 +42,15 @@ return [
             'slug'  =>'onboarded',
             'class' => 'badge badge-success'
         ],
+    ],
+    'domain' => [
+        'engineering' => [
+            'label' => 'Engineering',
+            'slug' => 'engineering',
+        ],
+        'design' => [
+            'label' => 'Design',
+            'slug' => 'design',
+        ],
     ]
 ];

--- a/Modules/CodeTrek/Database/Migrations/2023_07_07_170254_AddDomainNameToCodetrekApplicantTable.php
+++ b/Modules/CodeTrek/Database/Migrations/2023_07_07_170254_AddDomainNameToCodetrekApplicantTable.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
-class AddDomainNameToCodeTrekApplicantTable extends Migration
+class AddDomainNameToCodetrekApplicantTable extends Migration
 {
     /**
      * Run the migrations.

--- a/Modules/CodeTrek/Resources/views/edit.blade.php
+++ b/Modules/CodeTrek/Resources/views/edit.blade.php
@@ -94,11 +94,11 @@
                             </select>
                         </div>
                         <div class="form-group offset-md-1 col-md-5">
-                                <label for="domain" class="field-required">{{ __('Select Domain Name') }}</label>
+                                <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
                                 <select name="domain_type" id="domain_type" class="form-control" required>
                                     <option value="">Select Domain Name</option>
                                     @foreach (config('codetrek.domain') as $key => $domain)
-                                        <option value="{{ $domain["slug"] }}" {{ old('domain_type') == $key ? 'selected' : '' }}>{{ $domain['label'] }}</option>
+                                        <option value="{{ $domain["slug"] }}" {{ $applicant->domain_name == $domain["slug"] ? 'selected' : '' }}>{{ $domain['label'] }}</option>
                                     @endforeach
                                 </select>
                             </div>

--- a/Modules/CodeTrek/Resources/views/edit.blade.php
+++ b/Modules/CodeTrek/Resources/views/edit.blade.php
@@ -94,7 +94,7 @@
                             </select>
                         </div>
                         <div class="form-group offset-md-1 col-md-5">
-                            <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
+                            <label for="domain" class="field-required">Domain Name</label>
                             <select name="domain" id="domain" class="form-control" required>
                                 <option value="">Select Domain Name</option>
                                 @foreach (config('codetrek.domain') as $key => $domain)

--- a/Modules/CodeTrek/Resources/views/edit.blade.php
+++ b/Modules/CodeTrek/Resources/views/edit.blade.php
@@ -93,6 +93,15 @@
                                 @endforeach
                             </select>
                         </div>
+                        <div class="form-group offset-md-1 col-md-5">
+                                <label for="domain" class="field-required">{{ __('Select Domain Name') }}</label>
+                                <select name="domain_type" id="domain_type" class="form-control" required>
+                                    <option value="">Select Domain Name</option>
+                                    @foreach (config('codetrek.domain') as $key => $domain)
+                                        <option value="{{ $domain["slug"] }}" {{ old('domain_type') == $key ? 'selected' : '' }}>{{ $domain['label'] }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
                     </div>
                     <button type="submit" class="btn btn-primary save-btn">Save</button>
                     <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete">Delete</button>

--- a/Modules/CodeTrek/Resources/views/edit.blade.php
+++ b/Modules/CodeTrek/Resources/views/edit.blade.php
@@ -95,7 +95,7 @@
                         </div>
                         <div class="form-group offset-md-1 col-md-5">
                                 <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
-                                <select name="domain_type" id="domain_type" class="form-control" required>
+                                <select name="domain" id="domain" class="form-control" required>
                                     <option value="">Select Domain Name</option>
                                     @foreach (config('codetrek.domain') as $key => $domain)
                                         <option value="{{ $domain["slug"] }}" {{ $applicant->domain_name == $domain["slug"] ? 'selected' : '' }}>{{ $domain['label'] }}</option>

--- a/Modules/CodeTrek/Resources/views/edit.blade.php
+++ b/Modules/CodeTrek/Resources/views/edit.blade.php
@@ -94,14 +94,14 @@
                             </select>
                         </div>
                         <div class="form-group offset-md-1 col-md-5">
-                                <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
-                                <select name="domain" id="domain" class="form-control" required>
-                                    <option value="">Select Domain Name</option>
-                                    @foreach (config('codetrek.domain') as $key => $domain)
-                                        <option value="{{ $domain["slug"] }}" {{ $applicant->domain_name == $domain["slug"] ? 'selected' : '' }}>{{ $domain['label'] }}</option>
-                                    @endforeach
-                                </select>
-                            </div>
+                            <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
+                            <select name="domain" id="domain" class="form-control" required>
+                                <option value="">Select Domain Name</option>
+                                @foreach (config('codetrek.domain') as $key => $domain)
+                                    <option value="{{ $domain["slug"] }}" {{ $applicant->domain_name == $domain["slug"] ? 'selected' : '' }}>{{ $domain['label'] }}</option>
+                                @endforeach
+                            </select>
+                        </div>
                     </div>
                     <button type="submit" class="btn btn-primary save-btn">Save</button>
                     <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirm-delete">Delete</button>

--- a/Modules/CodeTrek/Resources/views/modals/add-applicant-modal.blade.php
+++ b/Modules/CodeTrek/Resources/views/modals/add-applicant-modal.blade.php
@@ -95,7 +95,7 @@
                                 </select>
                             </div>
                             <div class="form-group offset-md-1 col-md-5">
-                                <label for="domain" class="field-required">{{ __('Select Domain Name') }}</label>
+                                <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
                                 <select name="domain" id="domain" class="form-control" required>
                                     <option value="">Select Domain Name</option>
                                     @foreach (config('codetrek.domain') as $key => $domain)

--- a/Modules/CodeTrek/Resources/views/modals/add-applicant-modal.blade.php
+++ b/Modules/CodeTrek/Resources/views/modals/add-applicant-modal.blade.php
@@ -95,7 +95,7 @@
                                 </select>
                             </div>
                             <div class="form-group offset-md-1 col-md-5">
-                                <label for="domain" class="field-required">{{ __('Domain Name') }}</label>
+                                <label for="domain" class="field-required">Domain Name</label>
                                 <select name="domain" id="domain" class="form-control" required>
                                     <option value="">Select Domain Name</option>
                                     @foreach (config('codetrek.domain') as $key => $domain)

--- a/Modules/CodeTrek/Resources/views/modals/add-applicant-modal.blade.php
+++ b/Modules/CodeTrek/Resources/views/modals/add-applicant-modal.blade.php
@@ -94,6 +94,15 @@
                                     @endforeach
                                 </select>
                             </div>
+                            <div class="form-group offset-md-1 col-md-5">
+                                <label for="domain" class="field-required">{{ __('Select Domain Name') }}</label>
+                                <select name="domain" id="domain" class="form-control" required>
+                                    <option value="">Select Domain Name</option>
+                                    @foreach (config('codetrek.domain') as $key => $domain)
+                                        <option value="{{ $domain["slug"] }}" >{{ $domain['label'] }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
                         </div>
                     </div>
                     <div class="card-footer">

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -70,10 +70,12 @@ class CodeTrekService
         $applicant->university = $data['university_name'] ?? null;
         $applicant->centre_id = $data['centre'];
         $applicant->mentor_id = $data['mentorId'];
+        $applicant->domain_name = $data['domain'];
+        $applicant->latest_round_name = "level-1";
         // Mail::queue(new CodetrekMailApplicant($data)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
         $applicant->save();
 
-        $this->moveApplicantToRound($applicant, $data);
+        $this->moveApplicantToRoundOne($applicant, $data);
 
         return $applicant;
     }
@@ -97,6 +99,7 @@ class CodeTrekService
         $applicant->university = $data['university_name'] ?? null;
         $applicant->centre_id = $data['centre'] ?? null;
         $applicant->mentor_id = $data['mentorId'] ?? null;
+        $applicant->domain_name = $data['domian_name'];
         $applicant->save();
 
         return $applicant;
@@ -109,7 +112,7 @@ class CodeTrekService
         return $roundDetails;
     }
 
-    public function moveApplicantToRound($applicant, $data)
+    public function moveApplicantToRoundOne($applicant, $data)
     {
         $applicationRound = new CodeTrekApplicantRoundDetail();
         $applicationRound->applicant_id = $applicant->id;

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -71,7 +71,7 @@ class CodeTrekService
         $applicant->centre_id = $data['centre'];
         $applicant->mentor_id = $data['mentorId'];
         $applicant->domain_name = $data['domain'];
-        $applicant->latest_round_name = 'level-1';
+        $applicant->latest_round_name = config('codetrek.rounds.level-1.slug');
         // Mail::queue(new CodetrekMailApplicant($data)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
         $applicant->save();
 

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -71,7 +71,7 @@ class CodeTrekService
         $applicant->centre_id = $data['centre'];
         $applicant->mentor_id = $data['mentorId'];
         $applicant->domain_name = $data['domain'];
-        $applicant->latest_round_name = "level-1";
+        $applicant->latest_round_name = 'level-1';
         // Mail::queue(new CodetrekMailApplicant($data)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
         $applicant->save();
 

--- a/Modules/CodeTrek/Services/CodeTrekService.php
+++ b/Modules/CodeTrek/Services/CodeTrekService.php
@@ -99,7 +99,7 @@ class CodeTrekService
         $applicant->university = $data['university_name'] ?? null;
         $applicant->centre_id = $data['centre'] ?? null;
         $applicant->mentor_id = $data['mentorId'] ?? null;
-        $applicant->domain_name = $data['domian_name'];
+        $applicant->domain_name = $data['domain'];
         $applicant->save();
 
         return $applicant;

--- a/database/migrations/2023_07_07_123151_add_domain_name_to_code_trek_applicant_table.php
+++ b/database/migrations/2023_07_07_123151_add_domain_name_to_code_trek_applicant_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDomainNameToCodeTrekApplicantTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('code_trek_applicants', function (Blueprint $table) {
+            $table->string('domain_name')->nullable(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('code_trek_applicants', function (Blueprint $table) {
+            $table->dropColumn('domain_name');
+        });
+    }
+}


### PR DESCRIPTION
Targets #3253 

### Description
Currently, the "Add New Participant" form in CodeTrak lacks a crucial element: a dropdown menu to select the domain of the participant. This dropdown menu is essential as CodeTrak provides training to candidates from various domains. Without this dropdown, it becomes challenging to accurately categorize and manage participants based on their domains.

### Solution:
This pull request enhances the "Add New Participant" form by adding a dropdown menu that allows users to select the domain of the new participant. The dropdown menu is labeled as "Domain" and is a required field for form submission. The dropdown options are pre-populated with the values "Engineering" and "Design" based on the configuration array config('codetrek.type'). The dropdown is also designed to accommodate future domain options as the organization grows.

### Expected Changes:
- Integrate a dropdown menu into the "Add New Participant" form. 
- Label the dropdown menu as "Domain" or "Select Domain Name."
- Pre-populate the dropdown menu with the options "Engineering" and "Design."
- Ensure the dropdown menu is expandable to include future domain options.
- Validate the domain selection to prevent submission with an empty or invalid selection.
- Add the selected domain to the backend.

### Expected Time
- [x] Integrate a dropdown menu into the "Add New Participant" form: 0.5-1 hours
- [x] Label the dropdown menu as "Domain" or "Select Domain Name": 30 minutes
- [x] Pre-populate the dropdown menu with the options "Engineering" and "Design": 1 hour
- [x] Make the dropdown menu expandable to include future domain options: 1 hour
- [x] Implement domain selection validation: 1-2 hours
- [x] Add the selected domain to the backend: 1-2 hours

**Total Expected Time: 5 - 7.5 hours**
### Checklist:

- [x] I have performed a self-review of my own code.
