### PR TITLE
Sort Universities by most applications received. #2443

### DIFF
--- a/Modules/HR/Services/UniversityService.php
+++ b/Modules/HR/Services/UniversityService.php
@@ -4,7 +4,6 @@ namespace Modules\HR\Services;
 
 use Modules\HR\Entities\University;
 use Modules\HR\Contracts\UniversityServiceContract;
-use Illuminate\Support\Facades\DB;
 
 class UniversityService implements UniversityServiceContract
 {

--- a/Modules/HR/Services/UniversityService.php
+++ b/Modules/HR/Services/UniversityService.php
@@ -13,7 +13,7 @@ class UniversityService implements UniversityServiceContract
         if (! $filteredString) {
             return University::select('hr_universities.*')
             ->leftJoin('hr_applicants', 'hr_universities.id', '=', 'hr_applicants.hr_university_id')
-            ->orderBy(DB::raw('count(hr_applicants.hr_university_id)'), 'desc')
+            ->orderByRaw('COUNT(hr_applicants.hr_university_id) DESC')
             ->groupBy('hr_universities.id')
             ->paginate(config('constants.pagination_size'));
         }


### PR DESCRIPTION
Targets #2443 
### Description
This pull request addresses the task of sorting universities based on the number of applications received. Currently, the universities are listed in the order of their addition dates. With this change, the universities will be listed in descending order of the number of applications they have received. This default sorting order will allow users to quickly identify universities with the highest application counts.

###  Changes Made:
- Updated the sorting order of universities in the HR universities page.
- Replaced the previous sorting logic with a new one that counts the number of applications associated with each university.

### Expected Time

- [x] Sorted Universities by most applications received. .2-4 hours

**Total Time Taken:** 2 hours
### Checklist:
- [x] I have performed a self-review of my own code.
