### PR TITLE
#3273 Send codetrek onboarded applicant data to HR module

### DIFF
--- a/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
+++ b/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
@@ -2,10 +2,14 @@
 
 namespace Modules\CodeTrek\Services;
 
-use Modules\CodeTrek\Entities\CodeTrekApplicant;
-use Modules\CodeTrek\Entities\CodeTrekApplicantRoundDetail;
+use Modules\HR\Entities\Applicant;
+use Modules\HR\Entities\Application;
+use Modules\HR\Entities\ApplicationMeta;
+use Modules\HR\Entities\ApplicationRound;
 use Illuminate\Support\Facades\Mail;
+use Modules\CodeTrek\Entities\CodeTrekApplicant;
 use Modules\CodeTrek\Emails\CodeTrekApplicantRoundMail;
+use Modules\CodeTrek\Entities\CodeTrekApplicantRoundDetail;
 
 class CodeTrekRoundDetailService
 {
@@ -37,6 +41,71 @@ class CodeTrekRoundDetailService
         $applicationRound->start_date = today();
         $codetrekApplicant = CodeTrekApplicant::find($applicant->id);
         // Mail::send(new CodeTrekApplicantRoundMail($applicationRound, $codetrekApplicant)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
+        $this->codetrekApplicantStore($applicant);
         $applicationRound->save();
     }
+
+    public function codetrekApplicantStore($applicant)
+    {
+
+        $hrApplicant = new Applicant();
+        $hrApplicant->name = $applicant->first_name . ' ' . $applicant->last_name;
+        $hrApplicant->email = $applicant->email;
+        $hrApplicant->phone = $applicant->phone;
+        $hrApplicant->wa_optin_at = $applicant->null;
+        $hrApplicant->linkedin = $applicant->null;
+        $hrApplicant->hr_university_id = $applicant->null;
+        $hrApplicant->course = $applicant->course;
+        $hrApplicant->graduation_year = $applicant->graduation_year;
+        $hrApplicant->college = $applicant->university;
+        
+        $hrApplicant->save();
+        $this->codetrekApplicationStore($hrApplicant,$applicant);
+    }
+
+    public function codetrekApplicationStore($hrApplicant,$applicant)
+    {
+        $hrApplication = new Application();
+        
+        $hrApplication->hr_applicant_id = $hrApplicant->id;
+        $hrApplication->hr_job_id = 38;
+        $hrApplication->status = config('constants.hr.status.sent-for-approval.label');
+        $hrApplication->hr_channel_id = 1;
+        $hrApplication->applicant_type = 'codetrek';
+        $hrApplication->is_verified = 0;
+        $hrApplication->offer_letter = $applicant->null;
+        $hrApplication->resume = $applicant->null;
+        $hrApplication->autoresponder_subject = $applicant->null;
+        $hrApplication->autoresponder_body = $applicant->null;
+        $hrApplication->pending_approval_from = $applicant->null;
+
+
+        $hrApplication->save();
+        $this->codetrekApplicationMetaStore($hrApplication,$applicant);
+        $this->codetrekApplicationRoundStore($hrApplication,$applicant);
+    }
+
+    public function codetrekApplicationMetaStore($hrApplication,$applicant)
+    {
+         ApplicationMeta::create([
+            'hr_application_id' => $hrApplication->id,
+            'value' => json_encode([
+                'conducted_person_id' => $applicant->mentor_id,
+                'supervisor_id' => $applicant->mentor_id,
+            ]),
+        ]);
+    }
+
+    public function codetrekApplicationRoundStore($hrApplication,$applicant)
+    {
+        $hrApplicationRound = new ApplicationRound();
+
+        $hrApplicationRound->hr_application_id = $hrApplication->id;
+        $hrApplicationRound->hr_round_id = 1;
+        $hrApplicationRound->scheduled_person_id = 1;
+        $hrApplicationRound->conducted_person_id = $applicant->mentor_id;
+        
+        $hrApplicationRound->save();
+    }
+
 }

--- a/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
+++ b/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
@@ -41,10 +41,11 @@ class CodeTrekRoundDetailService
         $applicationRound->start_date = today();
         $codetrekApplicant = CodeTrekApplicant::find($applicant->id);
         // Mail::send(new CodeTrekApplicantRoundMail($applicationRound, $codetrekApplicant)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
-        if ($applicationRound->latest_round_name === 'onboarded')
+        if ($applicationRound->latest_round_name === 'onboarded') {
             $this->codetrekApplicantStore($applicant);
-        else
+        } else {
             $applicationRound->save();
+        }
     }
 
     public function codetrekApplicantStore($applicant)

--- a/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
+++ b/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
@@ -41,10 +41,10 @@ class CodeTrekRoundDetailService
         $applicationRound->start_date = today();
         $codetrekApplicant = CodeTrekApplicant::find($applicant->id);
         // Mail::send(new CodeTrekApplicantRoundMail($applicationRound, $codetrekApplicant)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
-       if($applicationRound->latest_round_name === 'onboarded')
-        $this->codetrekApplicantStore($applicant);
+        if ($applicationRound->latest_round_name === 'onboarded')
+            $this->codetrekApplicantStore($applicant);
         else
-        $applicationRound->save();
+            $applicationRound->save();
     }
 
     public function codetrekApplicantStore($applicant)
@@ -60,7 +60,7 @@ class CodeTrekRoundDetailService
         $hrApplicant->course = $applicant->course;
         $hrApplicant->graduation_year = $applicant->graduation_year;
         $hrApplicant->college = $applicant->university;
-        
+
         $hrApplicant->save();
         $this->codetrekApplicationStore($hrApplicant, $applicant);
     }
@@ -68,7 +68,7 @@ class CodeTrekRoundDetailService
     public function codetrekApplicationStore($hrApplicant, $applicant)
     {
         $hrApplication = new Application();
-        
+
         $hrApplication->hr_applicant_id = $hrApplicant->id;
         $hrApplication->hr_job_id = 38;
         $hrApplication->status = config('constants.hr.status.sent-for-approval.label');
@@ -105,7 +105,7 @@ class CodeTrekRoundDetailService
         $hrApplicationRound->hr_round_id = 1;
         $hrApplicationRound->scheduled_person_id = 1;
         $hrApplicationRound->conducted_person_id = $applicant->mentor_id;
-        
+
         $hrApplicationRound->save();
     }
 }

--- a/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
+++ b/Modules/CodeTrek/Services/CodeTrekRoundDetailService.php
@@ -41,14 +41,16 @@ class CodeTrekRoundDetailService
         $applicationRound->start_date = today();
         $codetrekApplicant = CodeTrekApplicant::find($applicant->id);
         // Mail::send(new CodeTrekApplicantRoundMail($applicationRound, $codetrekApplicant)); This line will be uncommented in the future when the use of the codeTrek module starts in the proper way.
+       if($applicationRound->latest_round_name === 'onboarded')
         $this->codetrekApplicantStore($applicant);
+        else
         $applicationRound->save();
     }
 
     public function codetrekApplicantStore($applicant)
     {
-
         $hrApplicant = new Applicant();
+
         $hrApplicant->name = $applicant->first_name . ' ' . $applicant->last_name;
         $hrApplicant->email = $applicant->email;
         $hrApplicant->phone = $applicant->phone;
@@ -60,10 +62,10 @@ class CodeTrekRoundDetailService
         $hrApplicant->college = $applicant->university;
         
         $hrApplicant->save();
-        $this->codetrekApplicationStore($hrApplicant,$applicant);
+        $this->codetrekApplicationStore($hrApplicant, $applicant);
     }
 
-    public function codetrekApplicationStore($hrApplicant,$applicant)
+    public function codetrekApplicationStore($hrApplicant, $applicant)
     {
         $hrApplication = new Application();
         
@@ -79,15 +81,14 @@ class CodeTrekRoundDetailService
         $hrApplication->autoresponder_body = $applicant->null;
         $hrApplication->pending_approval_from = $applicant->null;
 
-
         $hrApplication->save();
-        $this->codetrekApplicationMetaStore($hrApplication,$applicant);
-        $this->codetrekApplicationRoundStore($hrApplication,$applicant);
+        $this->codetrekApplicationMetaStore($hrApplication, $applicant);
+        $this->codetrekApplicationRoundStore($hrApplication, $applicant);
     }
 
-    public function codetrekApplicationMetaStore($hrApplication,$applicant)
+    public function codetrekApplicationMetaStore($hrApplication, $applicant)
     {
-         ApplicationMeta::create([
+        ApplicationMeta::create([
             'hr_application_id' => $hrApplication->id,
             'value' => json_encode([
                 'conducted_person_id' => $applicant->mentor_id,
@@ -96,7 +97,7 @@ class CodeTrekRoundDetailService
         ]);
     }
 
-    public function codetrekApplicationRoundStore($hrApplication,$applicant)
+    public function codetrekApplicationRoundStore($hrApplication, $applicant)
     {
         $hrApplicationRound = new ApplicationRound();
 
@@ -107,5 +108,4 @@ class CodeTrekRoundDetailService
         
         $hrApplicationRound->save();
     }
-
 }

--- a/Modules/HR/Resources/views/application/render-application-row.blade.php
+++ b/Modules/HR/Resources/views/application/render-application-row.blade.php
@@ -100,20 +100,27 @@
             </div>
         </div>
 
-        <div>
-            @if ($application->applicant->linkedin)
-                <a href="{{ $application->applicant->linkedin }}" target="_blank" data-toggle="tooltip"
-                    data-placement="top" title="LinkedIn" class="mr-1 text-decoration-none">
-                    <span><i class="fa fa-linkedin-square" aria-hidden="true"></i></span>
-                </a>
-            @endif
-            @if ($application->resume)
-                <a href="{{ $application->resume }}" target="_blank" data-toggle="tooltip" data-placement="top"
-                    title="Resume" class="mr-1 text-decoration-none">
-                    <span><i class="fa fa-file-text" aria-hidden="true"></i></span>
-                </a>
-            @endif
-        </div>
+        <div class="d-flex justify-content-between">
+            <div>
+                @if ($application->applicant->linkedin)
+                    <a href="{{ $application->applicant->linkedin }}" target="_blank" data-toggle="tooltip"
+                        data-placement="top" title="LinkedIn" class="mr-1 text-decoration-none">
+                        <span><i class="fa fa-linkedin-square" aria-hidden="true"></i></span>
+                    </a>
+                @endif
+                @if ($application->resume)
+                    <a href="{{ $application->resume }}" target="_blank" data-toggle="tooltip" data-placement="top"
+                        title="Resume" class="mr-1 text-decoration-none">
+                        <span><i class="fa fa-file-text" aria-hidden="true"></i></span>
+                    </a>
+                @endif
+            </div>
+            <div class="">
+                @if ($application->applicant_type === 'codetrek')
+                <span class="badge badge-pill badge-dark">Codetrek</span>
+                @endif
+            </div>
+           </div>
     </td>
     <td>
         <div class="d-flex flex-column">

--- a/database/migrations/2023_07_12_172307_add_column_applicant_type_to_hr_applications.php
+++ b/database/migrations/2023_07_12_172307_add_column_applicant_type_to_hr_applications.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnApplicantTypeToHrApplications extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hr_applications', function (Blueprint $table) {
+            $table->string('applicant_type')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hr_applications', function (Blueprint $table) {
+            $table->dropColumn('applicant_type');
+        });
+    }
+}


### PR DESCRIPTION
## Targets #3273

### Description
Sent the `codetrek` onboarded applicant data to the `HR module` for easy access and evaluation of the candidate also add a label to differentiate between the `codetrek` applicants and `HR` applicants.

## Breakdown & Estimates 
### Expected Time

- [x] Understand the flow of the data. `5-6 hours`
- [x] Add the onboarded candidate data to the HR module database. `3-4 hours`
- [x] Show onboarded candidate details in the to-approve tab. `3-4 hours`
- [x] For testing, code review, and documentation. `2-3 hours`


### Actual Time

- [x] Understand the flow of the data. `9-10 hours`
- [x] Add the onboarded candidate data to the HR module database. `6-7 hours`
- [x] Show onboarded candidate details in the to-approve tab. ` 4-5 hours`
- [x] For testing, code review, and documentation. ` 2-3 hours`

### `TOTAL TIME = 25 HOURS`

## Unit Testing

- When selecting any option from the dropdown, it sends the data to the `hr_applicant` table. The bug is fixed now. 

![image](https://github.com/ColoredCow/portal/assets/120373044/2b72c06b-0bc4-4099-b75b-6c612db45731)



## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: #3278
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.
