### PR TITLE
2687 Multiple email templates option upon rejection

### DIFF
--- a/Modules/HR/Database/Seeders/SettingsTableSeeder.php
+++ b/Modules/HR/Database/Seeders/SettingsTableSeeder.php
@@ -126,5 +126,15 @@ class SettingsTableSeeder extends Seeder
             'setting_key' => 'approved_mail_body',
             'setting_value' => '<div>Dear |APPLICANT NAME|,</div><div><br> </div><div>We are pleased to inform you that you have been selected for the post of |JOB TITLE| with us and your joining with ColoredCow shall stand confirmed with effect after date of signing.</div><div><br> </div><div>The Draft copy of the Offer Letter is enclosed herewith with the details of your appointment with us. We would appreciate it if you go through it and share the acceptance with us within 3 days. Please fill out the form for the personal documents like Aadhar, PAN and bank details in order to raise an offer letter.</div><div><br></div><div>We look forward to a long term association and a rewarding career for you.</div><div><br></div><div>Please Fill your details using the following link</div><div><br></div><div><a href="|LINK|"> Fill Form</a></div><div><br></div><div>Thanks</div><div><br> </div><div>HR, Team.</div>',
         ]);
+        Setting::updateOrCreate([
+            'module' => 'hr',
+            'setting_key' => 'codetrek_proposition_subject',
+            'setting_value' => 'Your Job application with ColoredCow',
+        ]);
+        Setting::updateOrCreate([
+            'module' => 'hr',
+            'setting_key' => 'codetrek_proposition_body',
+            'setting_value' => '<div>Hello |APPLICANT NAME|,</div><div> </div><div>Thanks for considering ColoredCow as your next Career choice.</div><div>As we see you applied for |JOB TITLE| but somehow this job requires different skills than your current resume reflects.</div><div>Alternatively, if you want to build your Software Development skills as a Trainee, we are inviting candidates to our Tehri and Dwarahat offices. Drop us an email at arushi.dubey@coloredcow.in to know more about the program.</div><div>Thanks again for applying. </div><div>HR Team,</div><div>ColoredCow</div> ',
+        ]);
     }
 }

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -28,6 +28,7 @@ use Modules\HR\Http\Requests\TeamInteractionRequest;
 use Modules\HR\Services\ApplicationService;
 use Modules\User\Entities\User;
 use niklasravnsborg\LaravelPdf\Facades\Pdf;
+use Modules\HR\Http\Controllers\Recruitment\ApplicationRoundController;
 
 abstract class ApplicationController extends Controller
 {
@@ -242,6 +243,27 @@ abstract class ApplicationController extends Controller
             'subject' => $subject->setting_value,
             'body' => $body->setting_value,
         ]);
+    }
+
+    public function generateRejectionEmail(Request $request)
+    {
+        if($request->setting_key_subject == 'codetrek_proposition_subject')
+        {
+            $subject = Setting::where('module', 'hr')->where('setting_key', $request->setting_key_subject)->first();
+            $body = Setting::where('module', 'hr')->where('setting_key', $request->setting_key_body)->first();
+            $body->setting_value = str_replace('|APPLICANT NAME|', $request->applicant_name, $body->setting_value);
+            $body->setting_value = str_replace('|JOB TILE|', $request->job_title, $body->setting_value);
+            return response()->json([
+                'subject' => $subject,
+                'body' => $body,
+            ]);
+        }
+        else
+        {
+            dd(getMailContent($request->applicationRound,'rejected'));
+            return response()->json(getMailContent($request->applicationRound,'reject'));
+        }
+        
     }
 
     public function saveOfferLetter(Application $application)

--- a/Modules/HR/Routes/web.php
+++ b/Modules/HR/Routes/web.php
@@ -99,6 +99,7 @@ Route::middleware('auth')->group(function () {
             Route::post('/teaminteraction', 'JobApplicationController@generateTeamInteractionEmail');
             Route::get('/finishinterview', 'JobApplicationController@markInterviewFinished')->name('markInterviewFinished');
             Route::get('/onHoldEmail', 'JobApplicationController@generateOnHoldEmail');
+            Route::get('/rejectEmail', 'JobApplicationController@generateRejectionEmail');
 
             Route::resource('internship', 'InternshipApplicationController')
                 ->only(['index', 'edit'])

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2033,20 +2033,72 @@ $(".opt").on("click", function() {
 		success: function(response) {
 			$("#option1subject").val(response.subject);
 			tinymce.get("option1body").setContent(response.body, { format: "html" });
+
+			$("#option2subject").val(response.subject);
+			tinymce.get("option2body").setContent(response.body, { format: "html" });
 		},
+		error: function(xhr, status, error) {
+			console.log('Error:', error);
+		  },
 	});
 
 	var originUrl = window.location.origin;
 	$.ajax({
-		url: originUrl + "/hr/recruitment/onHoldEmail",
+		url: originUrl + "/hr/recruitment/rejectEmail",
 		type: "GET",
 		data: formData,
 		contentType: "application/json",
 		success: function(response) {
-			$("#option2subject").val(response.subject);
-			tinymce.get("option2body").setContent(response.body, { format: "html" });
+			$("#optionCodeTrekPropositionSubject").val(response.subject, {format: "html"});
+			tinymce.get("optionCodeTrekPropositionBody").setContent(response.body, { format: "html" });
 		},
+		error: function(xhr, status, error) {
+			console.log('Error:', error);
+		  },
 	});
+
+	// var originUrl = window.location.origin;
+	// $.ajax({
+	// 	url: originUrl + "/hr/recruitment/onHoldEmail",
+	// 	type: "GET",
+	// 	data: formData,
+	// 	contentType: "application/json",
+	// 	success: function(response) {
+	// 		$("#option2subject").val(response.subject);
+	// 		tinymce.get("option2body").setContent(response.body, { format: "html" });
+	// 	},
+	// });
+	// let status = 'rejected';
+	// let applicationRoundId = $("#current_applicationround_id").val();
+	// var originUrl = window.location.origin;
+	// $.ajax({
+	// 	url: `/hr/recruitment/applicationround/${applicationRoundId}/mail-content/${status}`,
+	// 	type: 'POST',
+	// 	dataType: 'json',
+	// 	success: function(mailContent) {
+	// 	  // Update the respective divisions with the mail content
+	// 	  console.log(mailContent.subject); // Output: Your Subject Valu
+	// 	  console.log(mailContent.body);
+	// 	  $("#rejectMailToApplicantSubject").val(mailContent.subject);
+	// 	  $("#rejectMailToApplicantBody").setContent(mailContent.body, { format: "html" });
+	// 	},
+	// 	error: function(xhr, status, error) {
+	// 	  console.log('Error:', error);
+	// 	},
+	// });
+
+	// var originUrl = window.location.origin;
+	// $.ajax({
+	// 	url: originUrl + "/hr/recruitment/onHoldEmail",
+	// 	type: "GET",
+	// 	data: formData,
+	// 	contentType: "application/json",
+	// 	success: function(response) {
+	// 		$("#optionCodeTrekPropositionSubject").val(response.subject);
+	// 		tinymce.get("optionCodeTrekPropositionBody").setContent(response.body, { format: "html" });
+	// 	},
+	// });
+
 });
 
 $(document).on("click", ".finish_interview", function(e) {

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -290,7 +290,7 @@
                                                                     <button type="button"
                                                                         class="btn btn-outline-danger ml-2"
                                                                         id="rejectApplication"
-                                                                        @click="rejectApplication()">Reject</button>
+                                                                        data-target="#application_reject_modal">Reject</button>
                                                                     @include('hr.application.rejection-modal',
                                                                         [
                                                                             'currentApplication' => $application,
@@ -1359,7 +1359,8 @@
                                                             {{-- @if ($applicantOpenApplications->count() > 1) --}}
                                                             <button type="button" class="btn btn-outline-danger ml-2"
                                                                 id="rejectApplication"
-                                                                @click="rejectApplication()">Reject</button>
+                                                                
+                                                                data-toggle="modal" data-target="#application_reject_modal">Reject</button>
                                                             @include('hr.application.rejection-modal', [
                                                                 'currentApplication' => $application,
                                                                 'allApplications' => $applicantOpenApplications,

--- a/resources/views/hr/application/rejection-modal.blade.php
+++ b/resources/views/hr/application/rejection-modal.blade.php
@@ -58,7 +58,7 @@
                     <div class="form-group col-md-12 d-flex align-items-center">
                         <div class="py-0.67">
                             <div class="custom-control custom-switch">
-                                <input type="checkbox" name="send_mail_to_applicant[reject]" class="custom-control-input send-mail-to-applicant" id="rejectSendMailToApplicant" data-target="#previewMailToApplicant" checked>
+                                <input type="checkbox" name="send_mail_to_applicant[reject]" class="custom-control-input send-mail-to-applicant" id="rejectSendMailToApplicant" data-target="#previewMailToApplicant, #rejectOptionContainer" checked>
                                 <label class="custom-control-label" for="rejectSendMailToApplicant">Send email</label>
                             </div>
                         </div>
@@ -68,15 +68,54 @@
                         </div>
                     </div>
                 </div>
-                <div class="form-row d-none" id="rejectMailToApplicantBlock">
-                    <div class="form-group col-md-12">
-                        <label for="rejectMailToApplicantSubject">Subject</label>
-                        <input type="text" name="mail_to_applicant[reject][subject]" id="rejectMailToApplicantSubject"
-                            class="form-control">
-                    </div>
-                    <div class="form-group col-md-12">
-                        <label for="rejectMailToApplicantBody">Body</label>
-                        <textarea name="mail_to_applicant[reject][body]" id="rejectMailToApplicantBody" class="form-control richeditor"></textarea>
+                <div class="container form-row" id="rejectOptionContainer">
+                    <div>
+                        <ul class="nav nav-tabs">
+                            <li class="nav-item"><a data-toggle="tab" href="#rejectApplicant" class="nav-link opt" data-key-subject='general_communication_subject' data-key-body='general_communication_body' >General Communication</a></li>
+                            <li class="nav-item"><a data-toggle="tab" href="#codeTrekProposition" class="nav-link opt" data-key-subject='codetrek_proposition_subject' data-key-body='codetrek_proposition_body'>CodeTrek Proposition</a></li>
+                        </ul>
+                        <div class="tab-content" id="rejectMailToApplicantBlock">
+                            <div class="tab-pane" id="rejectApplicant">
+                                <div class="card-body">
+                                    <div class="form-row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>Subject</label>
+                                                <input name="subject_option_1" type="text" class="form-control option-subject" id="rejectMailToApplicantSubject">
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>Mail body:</label>
+                                                <textarea name="body_option_1" id="rejectMailToApplicantBody" rows="10" class="richeditor form-control option-body"></textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane" id="codeTrekProposition">
+                                <div class="card-body">
+                                    <div class="form-row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>Subject</label>
+                                                <input name="subject_option_2" type="text" class="form-control option-subject" id="optionCodeTrekPropositionSubject" >
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="form-row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>Mail body:</label>
+                                                <textarea name="body_option_2" rows="10" class="richeditor form-control option-body" id="optionCodeTrekPropositionBody"></textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>  
                     </div>
                 </div>
                 <div class="form-row mt-2">


### PR DESCRIPTION
…bug the problem

Targets #2687 
<!--- 
If there is an open issue, please link to the issue here by replacing [ISSUE_ID]. For eg. #1202
-->

## Description of the changes
<!--- 
Describe your changes or approach in detail. Why these changes are required? What was implemented earlier and what you implemented?
-->
Th task involves rendering mail template on selecting reject option. The content of the mail change with the change in option selected. Right now we've added two such options.
1. General Communication
2. Codetrek Proposition

## Breakdown & Expected Estimates 

- [ ] Getting familiar with the HR modules - 1 hr
- [ ] Understanding the previously done similar work : 2 hr
- [ ] Working on the front end: 1 hr
- [ ] Working on the data flow : 2 hr
- [ ] Error Resolution : 3 hr

**Expected Time Range:** 9 hr

**Actual Time:** 

## Feedback Cycle
<!-- 
The number of times feedbacks are given in the PR. This needs to be updated by the reviewer
-->
**Cycle Count: 0**

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [ ] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.
