### PR TITLE
Single command to check all the CI workflows

### DIFF
--- a/app/Console/Commands/CheckCommand.php
+++ b/app/Console/Commands/CheckCommand.php
@@ -13,7 +13,10 @@ class CheckCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'check:ci {--with-tty : Disable output to TTY}';
+    protected $signature = 'check:ci 
+    {--with-tty : Disable output to TTY}
+    {--c|cypress : Include cypress test as well}
+    ';
 
     /**
      * The console command description.

--- a/app/Console/Commands/check.php
+++ b/app/Console/Commands/check.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class check extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'check';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Single command to check all CI checks';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        foreach ($this->getCommands() as $name => $command) {
+            $this->checkCommand($command, $name);
+        }
+
+        return 1;
+    }
+
+    private function checkCommand($command, $name)
+    {
+        $this->info("Running $name");
+
+        $process = new Process($command);
+
+        $process->run(function ($type, $line) {
+            $this->output->write($line);
+        });
+
+        if (! $process->isSuccessful()) {
+            $this->info("$name Failed.");
+            throw new ProcessFailedException($process);
+        }
+
+        $this->info("$name Completed.");
+        $this->info('---------------------------------------------------------------------------------------');
+
+        return 1;
+    }
+
+    private function getCommands()
+    {
+        $staticAnalysis = [
+            'php',
+            './vendor/bin/php-cs-fixer',
+            'fix',
+            '--config',
+            '.php-cs-fixer.php',
+            '--dry-run',
+            '--verbose',
+            '--diff',
+        ];
+
+        $laraStan = ['./vendor/bin/phpstan', 'analyse'];
+        $esLintFix = ['./node_modules/.bin/eslint', 'resources/js/',  '--ext', '.js,.vue', '--fix'];
+        $esLintCheck = ['./node_modules/.bin/eslint', 'resources/js/', '--ext', '.js,.vue'];
+
+        return [
+            'Php CS Fixer' => $staticAnalysis,
+            'laraStan' => $laraStan,
+            'Eslint fix' => $esLintFix,
+            'Eslint check' => $esLintCheck
+        ];
+    }
+}


### PR DESCRIPTION
- Writing a single command to check all the CI processes. 
- I believe this will help developers to run the command on their machine and solve them in the PR.

```sh
php artisan check:ci
php artisan check:ci --with-tty
```


<img width="1091" alt="image" src="https://github.com/ColoredCow/portal/assets/10670690/0b6103cb-3bde-4959-bc36-0089d0386efb">