### PR TITLE
[Fix]:- HR module recruitment page performance

### DIFF
--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -337,7 +337,7 @@ abstract class ApplicationController extends Controller
 
     public function viewOfferLetter(Application $application)
     {
-        if (! Storage::exists($application->offer_letter)) {
+        if (!Storage::exists($application->offer_letter)) {
             return false;
         }
 

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -7,7 +7,6 @@ use App\Models\Setting;
 use App\Models\Tag;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Response;

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -60,7 +60,7 @@ abstract class ApplicationController extends Controller
         // We need this so that we can redirect user to the older page number.
         // we can improve this logic in the future.
 
-        if (!session()->get('should_skip_page') && Str::endsWith($referer, 'edit')) {
+        if (! session()->get('should_skip_page') && Str::endsWith($referer, 'edit')) {
             session()->put(['should_skip_page' => true]);
 
             return redirect()->route(request()->route()->getName(), session()->get('previous_application_data'))->with('status', session()->get('status'));
@@ -263,7 +263,7 @@ abstract class ApplicationController extends Controller
         $pdf = Pdf::loadView('hr.application.draft-joining-letter', compact('applicant', 'job', 'offer_letter_body'));
         $fileName = FileHelper::getOfferLetterFileName($applicant, $pdf);
         $directory = 'app/public/' . config('constants.hr.offer-letters-dir');
-        if (!is_dir(storage_path($directory)) && !file_exists(storage_path($directory))) {
+        if (! is_dir(storage_path($directory)) && ! file_exists(storage_path($directory))) {
             mkdir(storage_path($directory), 0, true);
         }
         $fullPath = storage_path($directory . '/' . $fileName);
@@ -337,7 +337,7 @@ abstract class ApplicationController extends Controller
 
     public function viewOfferLetter(Application $application)
     {
-        if (!Storage::exists($application->offer_letter)) {
+        if (! Storage::exists($application->offer_letter)) {
             return false;
         }
 


### PR DESCRIPTION
**Description**
- Optimize the HR recruitment index function code and remove the unnecessary code.
- In this, we need to test this in the UAT env. I checked this in the latest database dump of uat in local it was working fine.  Initially, it was taking time 14 seconds to load the page.

**What do we need to do next**
- We need to clean up more code in this. Because there is some same code in the application service and controller, but we are not using this service right now, all the code is added in the controller. 
