### PR TITLE
#3412/Monthly Tax report is not showing Data 

### DIFF
--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -70,14 +70,14 @@ class Invoice extends Model implements Auditable
     }
     public function scopeInvoiceInaYear($query, $invoiceYear)
     {
-        if (! is_numeric($invoiceYear)) {
+        if (!is_numeric($invoiceYear)) {
             return $query;
         }
 
         $FYStartMonth = config('invoice.financial-month-details.financial_year_start_month');
         $FYEndMonth = config('invoice.financial-month-details.financial_year_end_month');
 
-        $startDate = "{$invoiceYear}- {$FYStartMonth}-01";
+        $startDate = "{$invoiceYear}-{$FYStartMonth}-01";
         $endDate = ($invoiceYear + 1) . "-{$FYEndMonth}-31";
 
         return $query->whereBetween('sent_on', [$startDate, $endDate]);

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -70,7 +70,7 @@ class Invoice extends Model implements Auditable
     }
     public function scopeInvoiceInaYear($query, $invoiceYear)
     {
-        if (!is_numeric($invoiceYear)) {
+        if (! is_numeric($invoiceYear)) {
             return $query;
         }
 


### PR DESCRIPTION
Targets #3412


## Description of the changes
The issue was caused by a space before the FYStartMonth in the $startDate variable, resulting in an incorrectly formatted date string. The space was present in the  code 
`$startDate = "{$invoiceYear}- {$FYStartMonth}-01";
`
To resolve this issue I removed the blank spaces 

## Breakdown & Estimates 

- [x] Replicate & Debug the issues: 2 - 4 hours
- [x] Fixed the Filters: 0.5- 1 hours


**Expected Time Range:**
4-6 Hours

**Actual Time:** 
4 Hour
## Feedback Cycle
<!-- 
The number of times feedbacks are given in the PR. This needs to be updated by the reviewer
-->
**Cycle Count: 0**

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.
