### PR TITLE
#3431/Display Invoice Changes and Percentages in Invoice Screen 

### DIFF
--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -189,10 +189,10 @@ class Invoice extends Model implements Auditable
         if ($lastMonthAmount != 0) {
             $percentage = number_format(($amountDifference / $lastMonthAmount) * 100, 2);
 
-            return "$amountDifference ($percentage%)";
-        } else {
-            return $amountDifference;
+            return "{$amountDifference} ({$percentage}%)";
         }
+
+        return $amountDifference;
     }
 
     public function invoiceAmounts()

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -184,10 +184,10 @@ class Invoice extends Model implements Auditable
             ->where('client_id', $this->client_id)->where('project_id', $this->project_id)
             ->orderBy('sent_on', 'DESC')
             ->first();
-        $lastMonthAmount = $lastMonthAmountDetail ? ((float) $lastMonthAmountDetail->amount + (float) $lastMonthAmountDetail->gst) : 0;
+        $lastMonthAmount = $lastMonthAmountDetail ? (float) $lastMonthAmountDetail->amount + (float) $lastMonthAmountDetail->gst : 0;
         $amountDifference = $currentMonthAmount - $lastMonthAmount;
         if ($lastMonthAmount != 0) {
-            $percentage = number_format(($amountDifference / $lastMonthAmount) * 100, 2);
+            $percentage = number_format($amountDifference / $lastMonthAmount * 100, 2);
 
             return "{$amountDifference} ({$percentage}%)";
         }

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -171,6 +171,29 @@ class Invoice extends Model implements Auditable
         return trim(optional($country)->currency_symbol . $amount);
     }
 
+    public function invoiceAmountDifference()
+    {
+        $amountDifference = 0;
+        $lastInvoiceEndDate = $this->sent_on->subMonth()->endOfMonth();
+        $amount = (float) $this->amount;
+        if ($this->client->type == 'indian') {
+            $amount += (float) $this->gst;
+        }
+        $currentMonthAmount = $amount;
+        $lastMonthAmountDetail = self::where('sent_on', '<', $lastInvoiceEndDate)
+            ->where('client_id', $this->client_id)->where('project_id', $this->project_id)
+            ->orderBy('sent_on', 'DESC')
+            ->first();
+        $lastMonthAmount = $lastMonthAmountDetail ? ((float) $lastMonthAmountDetail->amount + (float) $lastMonthAmountDetail->gst) : 0;
+        $amountDifference = $currentMonthAmount - $lastMonthAmount;
+        if ($lastMonthAmount != 0) {
+            $percentage = number_format(($amountDifference / $lastMonthAmount) * 100, 2);
+            return "$amountDifference ($percentage%)";
+        } else {
+            return $amountDifference;
+        }
+    }
+
     public function invoiceAmounts()
     {
         $amount = (int) $this->amount;

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -188,6 +188,7 @@ class Invoice extends Model implements Auditable
         $amountDifference = $currentMonthAmount - $lastMonthAmount;
         if ($lastMonthAmount != 0) {
             $percentage = number_format(($amountDifference / $lastMonthAmount) * 100, 2);
+
             return "$amountDifference ($percentage%)";
         } else {
             return $amountDifference;

--- a/Modules/Invoice/Resources/views/index.blade.php
+++ b/Modules/Invoice/Resources/views/index.blade.php
@@ -113,11 +113,17 @@
                             @endphp
                             <tr>
                                 <td>{{ $loop->iteration }}</td>
-                                <td>{{ $invoice->client->name }}</td>
+                                <td><a href="{{ route('reports.finance.dashboard.client', ['client_id' => $invoice->client->id]) }}">{{ $invoice->client->name }}</td>
                                 <td>{{ optional($invoice->project)->name ?: $invoice->client->name . ' Projects' }}</td>
                                 <td><a href="{{ route('invoice.edit', $invoice) }}">{{ $invoice->invoice_number }}</a>
                                 </td>
-                                <td>{{ $invoice->invoiceAmount() }}</td>
+                                <td>
+                                    {{ $invoice->invoiceAmount() }} </br>
+                                    <span class="{{ $invoice->invoiceAmountDifference() >= 0 ? 'text-success' : 'text-danger' }} small">
+                                        {{ $invoice->invoiceAmountDifference() }} 
+                                    </span>
+                                </td>
+                                
                                 <td class="text-center">
                                     {{ $invoice->sent_on->format(config('invoice.default-date-format')) }}</td>
                                 <td


### PR DESCRIPTION
Targets #3431
<!--- 
If there is an open issue, please link to the issue here by replacing [ISSUE_ID]. For eg. #1202
-->

## Description of the changes
Previously, the Invoice screen only displayed the total amount for each month, lacking crucial information about changes in the invoice amounts for each project compared to the last invoice. Additionally, there was no direct link for easy navigation to the revenue details for each client.

- Introduced a feature that calculates and displays the amount difference for each project between the current invoice and the last one.
- Implemented a percentage difference calculation for each project, providing users with a clear percentage representation of how much the invoice amount has changed.
- Added hyperlinks (href) for each client displayed in the Invoice screen.

## Breakdown & Estimates 

- [x] Create a function to get the last month's Invoice details for each client: 3 - 4 hours
- [x] Create  a function to get the difference of invoice for MoM: 3 - 4 hours
- [x] Add a field to show Invoice differences and percentages in the Invoice Listing: 3 - 4 hours
- [x] Implement Logic to change the color of the Amount difference for Increase and decrease of invoice: 3-4 hours
- [x] Added href link to easily navigate to revenue by client page: 1-2 hours



## Feedback Cycle
<!-- 
The number of times feedbacks are given in the PR. This needs to be updated by the reviewer
-->
**Cycle Count: 0**

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.
