### PR TITLE
#3437/Introduce Monthly Average Revenue in Clients by Revenue Page

### DIFF
--- a/Modules/Report/Resources/assets/js/app.js
+++ b/Modules/Report/Resources/assets/js/app.js
@@ -106,6 +106,7 @@ function clientWiseRevenueTrendsReport(reportsData) {
 	const canvasElementId = "clientWiseReportRevenueTrends";
 	const labels = reportsData.labels;
 	const currentPeriodTotalRevenue = reportsData.data.total_amount;
+	const averageRevenue = reportsData.data.average_amount;
 	const chartData = {
 		labels: labels,
 		datasets: [
@@ -129,7 +130,7 @@ function clientWiseRevenueTrendsReport(reportsData) {
 			responsive: true,
 			title: {
 				display: true,
-				text: "Total revenue: Rs. " + currentPeriodTotalRevenue
+				text: "Total Revenue: Rs. " + currentPeriodTotalRevenue + " | Average Revenue: Rs. " + averageRevenue,
 			},
 			scales: {
 				yAxes: [

--- a/Modules/Report/Services/Finance/RevenueReportService.php
+++ b/Modules/Report/Services/Finance/RevenueReportService.php
@@ -126,11 +126,13 @@ class RevenueReportService
                 $amountMonthWise = $data['amountMonthWise'];
             }
         }
+        $averageAmount = $totalAmount / count($amountMonthWise);
 
         return [
             'months' => array_keys($amountMonthWise),
             'amount' => array_values($amountMonthWise),
             'total_amount' => round($totalAmount, 2),
+            'average_amount' => round($averageAmount, 2),
         ];
     }
 


### PR DESCRIPTION
## Target - {#3437 }
## Description of the changes
Currently, our system displays the total revenue for each client, providing an overall financial snapshot. However, to enhance our analytical capabilities, we aim to introduce a month-wise average revenue metric for better insights into client performance. This will enable a more nuanced understanding of revenue patterns and facilitate more informed decision-making.

## Breakdown & Estimates 
- [x]  Implement Average Revenue in the Clients by Revenue page: 4 - 8 hours


## Feedback Cycle
<!-- 
The number of times feedbacks are given in the PR. This needs to be updated by the reviewer
-->
**Cycle Count: 0**

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.
