### PR TITLE
#3445 - Active project count & previous employee dashboard fixes

### DIFF
--- a/Modules/HR/Http/Controllers/EmployeeController.php
+++ b/Modules/HR/Http/Controllers/EmployeeController.php
@@ -39,7 +39,9 @@ class EmployeeController extends Controller
 
     public function show(Employee $employee)
     {
-        return view('hr.employees.show', ['employee' => $employee]);
+        $user = $employee->user()->withTrashed()->first();
+
+        return view('hr.employees.show', compact('employee', 'user'));
     }
 
     public function reports()

--- a/Modules/HR/Observers/EmployeeObserver.php
+++ b/Modules/HR/Observers/EmployeeObserver.php
@@ -36,19 +36,4 @@ class EmployeeObserver
             ]);
         }
     }
-
-    /**
-     * Handle the employee "updated" event.
-     *
-     * @param  Employee  $employee
-     * @return void
-     */
-    public function updated(Employee $employee)
-    {
-        if ($employee->user->name != $employee->name) {
-            $employee->user->update([
-                'name' => $employee->name,
-            ]);
-        }
-    }
 }

--- a/Modules/Report/Http/Controllers/UserReportController.php
+++ b/Modules/Report/Http/Controllers/UserReportController.php
@@ -17,9 +17,10 @@ class UserReportController extends Controller
         $this->userReportService = $userReportService;
     }
 
-    public function getFteData(Request $request, User $user)
+    public function getFteData(Request $request, $userId)
     {
         $type = $request->type;
+        $user = User::withTrashed()->find($userId);
 
         return $this->userReportService->getFteData($type, $user);
     }

--- a/Modules/Report/Routes/web.php
+++ b/Modules/Report/Routes/web.php
@@ -18,7 +18,7 @@ Route::prefix('report')->group(function () {
     Route::get('/show/{id}', 'ReportController@show')->name('report.show');
     Route::get('/delete/{id}', 'ReportController@delete')->name('report.delete');
     Route::post('/update/{id}', 'ReportController@update')->name('report.update');
-    Route::get('/get-fte-report/{user}', 'UserReportController@getFteData')->name('reports.fte.get-report-data');
+    Route::get('/get-fte-report/{userId}', 'UserReportController@getFteData')->name('reports.fte.get-report-data');
     Route::get('get-codetrek-report', 'CodeTrekController@getApplicantData')->name('reports.codetrek.get-report-data');
 
     Route::prefix('finance')->group(function () {

--- a/Modules/User/Http/Controllers/ProfileController.php
+++ b/Modules/User/Http/Controllers/ProfileController.php
@@ -21,8 +21,9 @@ class ProfileController extends ModuleBaseController
         return view('user::profile.index', $this->service->index());
     }
 
-    public function update(ProfileEditRequest $request, User $user)
+    public function update(ProfileEditRequest $request, $userId)
     {
+        $user = User::withTrashed()->find($userId);
         $user->name = $request->name;
         $user->nickname = $request->nickName;
         $user->employee->name = $request->name;

--- a/Modules/User/Routes/web.php
+++ b/Modules/User/Routes/web.php
@@ -27,7 +27,7 @@ Route::prefix('user')->middleware('auth')->group(function () {
     */
 
     Route::get('/profile', 'ProfileController@index')->name('user.profile');
-    Route::post('/profile/{user}/edit', 'ProfileController@update')->name('profile.update');
+    Route::post('/profile/{userId}/edit', 'ProfileController@update')->name('profile.update');
     Route::get('/user-settings', 'UserSettingsController@index')->name('user.settings');
     Route::post('/user-settings', 'UserSettingsController@update')->name('user.settings.update');
     Route::post('/add-staff-type', 'UserSettingsController@addStaffType');

--- a/app/Services/EmployeeService.php
+++ b/app/Services/EmployeeService.php
@@ -11,9 +11,7 @@ class EmployeeService
         $employees = Employee::applyFilters($filters)
             ->leftJoin('project_team_members', 'employees.user_id', '=', 'project_team_members.team_member_id')
             ->leftJoin('projects', 'project_team_members.project_id', '=', 'projects.id')
-            ->where('projects.status', 'active')
-            ->where('project_team_members.ended_on', null)
-            ->selectRaw('employees.*, team_member_id, count(team_member_id) as active_project_count')
+            ->selectRaw('employees.*, team_member_id, count(case when projects.status = "active" and project_team_members.ended_on is null then 1 else null end) as active_project_count')
             ->groupBy('employees.user_id')
             ->orderby('active_project_count', 'desc')
             ->get();

--- a/resources/views/hr/employees/basic-details.blade.php
+++ b/resources/views/hr/employees/basic-details.blade.php
@@ -7,7 +7,7 @@
     <br><br>
     <div class= "card">
         <div class="card-body">
-            @include('user::profile.show-basic-details',['user'=>$employee->user])
+            @include('user::profile.show-basic-details',['user' => $employee->user()->withTrashed()->first()])
         </div>
     </div>
 </div>

--- a/resources/views/hr/employees/index.blade.php
+++ b/resources/views/hr/employees/index.blade.php
@@ -72,14 +72,16 @@
                         </td>
                         <td>
                             @if ($employee->user == null)
-                                <span
-                                    class="text-danger font-weight-bold">{{ $employee->user ? $employee->user->ftes['main'] : 'NA' }}</span>
+                                <span class="text-danger font-weight-bold">
+                                    {{ $employee->user ? $employee->user->ftes['main'] : 'NA' }}
+                                </span>
                             @elseif ($employee->user->ftes['main'] > 1 && $employee->domain_id != null)
                                 <a class="text-success font-weight-bold"
                                     href={{ route('employees.alert', ['domain_id' => $employee->domain_id]) }}
-                                    style="text-decoration: none;">
-                                    {{ $employee->user->ftes['main'] }} &nbsp;&nbsp;&nbsp;<span class="text-danger"><i
-                                            class="fa fa-warning fa-lg"></i></span>
+                                    style="text-decoration: none;"
+                                >
+                                    {{ $employee->user->ftes['main'] }} &nbsp;&nbsp;&nbsp;
+                                    <span class="text-danger"><i class="fa fa-warning fa-lg"></i></span>
                                 </a>
                             @elseif ($employee->user->ftes['main'] >= 1)
                                 <span class="text-success font-weight-bold">{{ $employee->user->ftes['main'] }}</span>

--- a/resources/views/hr/employees/index.blade.php
+++ b/resources/views/hr/employees/index.blade.php
@@ -38,24 +38,20 @@
                 @foreach ($employees as $employee)
                     <tr>
                         <td>
-                            @if ($employee->user)
-                                <a href="{{ route('employees.show', $employee->id) }}">
-                                    @if ($employee->overall_status === 'pending' && $filters['status'] == 'current')
-                                        {{ $employee->name }} <span
-                                            class="{{ config('constants.review-tags.pending.class') }} badge-pill mr-1 mb-1">{{ config('constants.review-tags.pending.title') }}</span>
-                                    @elseif ($employee->overall_status === 'in-progress' && $filters['status'] == 'current')
-                                        {{ $employee->name }} <span
-                                            class="{{ config('constants.review-tags.in-progress.class') }} badge-pill mr-1 mb-1">{{ config('constants.review-tags.in-progress.title') }}</span>
-                                    @elseif ($employee->overall_status === 'completed' && $filters['status'] == 'current')
-                                        {{ $employee->name }} <span
-                                            class="{{ config('constants.review-tags.completed.class') }} badge-pill mr-1 mb-1">{{ config('constants.review-tags.completed.title') }}</span>
-                                    @else
-                                        {{ $employee->name }}
-                                    @endif
-                                </a>
-                            @else
-                                {{ $employee->name }}
-                            @endif
+                            <a href="{{ route('employees.show', $employee->id) }}">
+                                @if ($employee->overall_status === 'pending' && $filters['status'] == 'current')
+                                    {{ $employee->name }} <span
+                                        class="{{ config('constants.review-tags.pending.class') }} badge-pill mr-1 mb-1">{{ config('constants.review-tags.pending.title') }}</span>
+                                @elseif ($employee->overall_status === 'in-progress' && $filters['status'] == 'current')
+                                    {{ $employee->name }} <span
+                                        class="{{ config('constants.review-tags.in-progress.class') }} badge-pill mr-1 mb-1">{{ config('constants.review-tags.in-progress.title') }}</span>
+                                @elseif ($employee->overall_status === 'completed' && $filters['status'] == 'current')
+                                    {{ $employee->name }} <span
+                                        class="{{ config('constants.review-tags.completed.class') }} badge-pill mr-1 mb-1">{{ config('constants.review-tags.completed.title') }}</span>
+                                @else
+                                    {{ $employee->name }}
+                                @endif
+                            </a>
                         </td>
 
                         <td>

--- a/resources/views/hr/employees/show.blade.php
+++ b/resources/views/hr/employees/show.blade.php
@@ -22,97 +22,99 @@
                         </div>
                     @endif
                 </div>
-                @if(optional($employee->user()->withTrashed())->first()->avatar)
-                    <img src="{{ $employee->user()->withTrashed()->first()->avatar }}" class="w-100 h-100 rounded-circle">
+                @if(optional($user)->avatar)
+                    <img src="{{ $user->avatar }}" class="w-100 h-100 rounded-circle">
                 @endif
             </div>
             <hr class='bg-dark mx-4 pb-0.5'>
-            <div class="d-flex"><div class="font-weight-bold fz-24 pl-5 mt-5 mb-3 d-flex justify-content-inline">{{__('Current FTE: ')}}<div class=" ml-1 {{ $employee->user ? ($employee->user->ftes['main'] > 1 ? 'text-success' : 'text-danger') : 'text-secondary'}} font-weight-bold">{{ $employee->user ? $employee->user->ftes['main']  :'NA' }}</div></div>
-            <div class="font-weight-bold fz-24 pl-5 mt-5 mb-3 d-flex justify-content-inline">{{__('FTE(AMC): ')}}<div class=" ml-1 {{ $employee->user ? ($employee->user->ftes['amc'] > 1 ? 'text-success' : 'text-danger') : 'text-secondary'}} font-weight-bold">{{ $employee->user ? $employee->user->ftes['amc']  :'NA' }}</div></div></div>
+            <div class="d-flex"><div class="font-weight-bold fz-24 pl-5 mt-5 mb-3 d-flex justify-content-inline">{{__('Current FTE: ')}}<div class=" ml-1 {{ $user ? ($user->ftes['main'] > 1 ? 'text-success' : 'text-danger') : 'text-secondary'}} font-weight-bold">{{ $user ? $user->ftes['main']  :'NA' }}</div></div>
+            <div class="font-weight-bold fz-24 pl-5 mt-5 mb-3 d-flex justify-content-inline">{{__('FTE(AMC): ')}}<div class=" ml-1 {{ $user ? ($user->ftes['amc'] > 1 ? 'text-success' : 'text-danger') : 'text-secondary'}} font-weight-bold">{{ $user ? $user->ftes['amc']  :'NA' }}</div></div></div>
             <canvas class="w-full" id="userDashboardGraph"></canvas>
-            <input type="hidden" id="get_report_data_url" value={{ route('reports.fte.get-report-data', ['user' => $employee->user()->withTrashed()->first()]) }}>
-            <div class="font-weight-bold fz-24 pl-5 mt-5 mb-3">Project Details</div>
-            <div class="mx-5">
-                <table class="table">
-                    <thead>
-                        <tr class="bg-theme-gray text-light">
-                            <th scope="col" class="pb-3 lg-4"><div class="ml-2">Project Name</div></th>
-                            <th scope="col" class="pb-3 lg-4">Project Term</th>
-                            <th scope="col" class="lg-4">Expected Hours For Term</th>
-                            <th scope="col" class="lg-4">Expected Hours Till Today</th>
-                            <th scope="col" class="lg-4">Hours Booked <span data-toggle="tooltip" data-placement="right" title="Hours in effortsheet for the current project term."><i class="fa fa-question-circle"></i>&nbsp;</span></th>
-                            <th scope="col" class="lg-4">Velocity <span data-toggle="tooltip" data-placement="right" title="Its  the productivity of employee in a project for project term."><i class="fa fa-question-circle"></i>&nbsp;</span></th>
-                            <th scope="col" class="lg-4">
-                                FTE Covered
-                                <span data-toggle="tooltip" data-placement="right" title="This is portion of the overall FTE that is contributed to the projects by the employee from {{ today()->startOfMonth()->format('dS M') }} to {{ today()->subDay()->format('dS M') }}."  >
-                                    <i class="fa fa-question-circle"></i>&nbsp;
-                                </span>
-                            </th>
-                        </tr>
-                    </thead>
-                    <thead>
-                        @if(optional($employee->user)->activeProjectTeamMembers == null || ($employee->user)->activeProjectTeamMembers->isEmpty())
-                            </table>
-                            <div class="fz-lg-28 text-center mt-2">
-                                <div class="mb-4">Not in any project</div>
-                            </div>
-                        @else
-                            @foreach($employee->user->activeProjectTeamMembers as $activeProjectTeamMember)
-                                @if($activeProjectTeamMember->project->status == 'active')
-                                    <tr>
-                                        <td class="c-pointer">
-                                            <div class="ml-2">
-                                                <a href={{ route('project.show', $activeProjectTeamMember->project) }}>
-                                                    {{$activeProjectTeamMember->project->name}}
-                                                    @if($activeProjectTeamMember->project->is_amc)
-                                                        <div class="badge badge-pill badge-success mr-1 mt-1">AMC</div>
-                                                    @endif
-                                                </a>
-                                            </div>
-                                        </td>
-                                        <td>
-                                            <div>
-                                                {{ (Carbon\Carbon::parse($activeProjectTeamMember->project->client->month_start_date)->format('dS M')) }}
-                                                - {{ (Carbon\Carbon::parse($activeProjectTeamMember->project->client->month_end_date)->format('dS M')) }} / {{ count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, $activeProjectTeamMember->project->client->month_end_date)) }} days
-                                            </div>
-                                        </td>
-                    
-                                        <td>
-                                            <div>
-                                                {{ $activeProjectTeamMember->daily_expected_effort * count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, $activeProjectTeamMember->project->client->month_end_date)) }} hrs
-                                                / {{ count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, $activeProjectTeamMember->project->client->month_end_date)) }} days
-                                            </div>
-                                        </td>
-                    
-                                        <td>
-                                            <div>
-                                                {{ $activeProjectTeamMember->daily_expected_effort * count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, today()->subDay())) }} hrs
-                                                / {{ count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, today()->subDay())) }} days
-                                            </div>
-                                        </td>
-                    
-                                        <td>
-                                            <div class="{{ $activeProjectTeamMember->current_actual_effort >= ($activeProjectTeamMember->daily_expected_effort * count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, today()->subDay()))) ? 'text-success' : 'text-danger' }}"> {{ $activeProjectTeamMember->current_actual_effort }}
-                                            </div>
-                                        </td>
-                    
-                                        <td>
-                                            <div>
-                                                <div class="{{$activeProjectTeamMember->velocity >= 1 ? 'text-success' : 'text-danger' }}">
-                                                    {{$activeProjectTeamMember->velocity}}
+            <input type="hidden" id="get_report_data_url" value={{ route('reports.fte.get-report-data', ['userId' => $user->id]) }}>
+
+            @if ($employee->user)
+                <div class="font-weight-bold fz-24 pl-5 mt-5 mb-3">Active Project Details</div>
+                <div class="mx-5">
+                    <table class="table">
+                        <thead>
+                            <tr class="bg-theme-gray text-light">
+                                <th scope="col" class="pb-3 lg-4"><div class="ml-2">Project Name</div></th>
+                                <th scope="col" class="pb-3 lg-4">Project Term</th>
+                                <th scope="col" class="lg-4">Expected Hours For Term</th>
+                                <th scope="col" class="lg-4">Expected Hours Till Today</th>
+                                <th scope="col" class="lg-4">Hours Booked <span data-toggle="tooltip" data-placement="right" title="Hours in effortsheet for the current project term."><i class="fa fa-question-circle"></i>&nbsp;</span></th>
+                                <th scope="col" class="lg-4">Velocity <span data-toggle="tooltip" data-placement="right" title="Its  the productivity of employee in a project for project term."><i class="fa fa-question-circle"></i>&nbsp;</span></th>
+                                <th scope="col" class="lg-4">
+                                    FTE Covered
+                                    <span data-toggle="tooltip" data-placement="right" title="This is portion of the overall FTE that is contributed to the projects by the employee from {{ today()->startOfMonth()->format('dS M') }} to {{ today()->subDay()->format('dS M') }}."  >
+                                        <i class="fa fa-question-circle"></i>&nbsp;
+                                    </span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <thead>
+                            @if(optional($user)->activeProjectTeamMembers == null || optional($user)->activeProjectTeamMembers->isEmpty())
+                                <div class="fz-lg-28 text-center mt-2">
+                                    <div class="mb-4">Not in any project</div>
+                                </div>
+                            @else
+                                @foreach($user->activeProjectTeamMembers as $activeProjectTeamMember)
+                                    @if($activeProjectTeamMember->project->status == 'active')
+                                        <tr>
+                                            <td class="c-pointer">
+                                                <div class="ml-2">
+                                                    <a href={{ route('project.show', $activeProjectTeamMember->project) }}>
+                                                        {{$activeProjectTeamMember->project->name}}
+                                                        @if($activeProjectTeamMember->project->is_amc)
+                                                            <div class="badge badge-pill badge-success mr-1 mt-1">AMC</div>
+                                                        @endif
+                                                    </a>
                                                 </div>
                                             </td>
-                    
-                                        <td>
-                                            <div>{{$activeProjectTeamMember->fte}}</div>
-                                        </td>
-                                    </tr>
-                                @endif
-                            @endforeach
-                        @endif
-                    </thead>                    
-                </table>    
-            </div>
+                                            <td>
+                                                <div>
+                                                    {{ (Carbon\Carbon::parse($activeProjectTeamMember->project->client->month_start_date)->format('dS M')) }}
+                                                    - {{ (Carbon\Carbon::parse($activeProjectTeamMember->project->client->month_end_date)->format('dS M')) }} / {{ count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, $activeProjectTeamMember->project->client->month_end_date)) }} days
+                                                </div>
+                                            </td>
+                        
+                                            <td>
+                                                <div>
+                                                    {{ $activeProjectTeamMember->daily_expected_effort * count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, $activeProjectTeamMember->project->client->month_end_date)) }} hrs
+                                                    / {{ count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, $activeProjectTeamMember->project->client->month_end_date)) }} days
+                                                </div>
+                                            </td>
+                        
+                                            <td>
+                                                <div>
+                                                    {{ $activeProjectTeamMember->daily_expected_effort * count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, today()->subDay())) }} hrs
+                                                    / {{ count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, today()->subDay())) }} days
+                                                </div>
+                                            </td>
+                        
+                                            <td>
+                                                <div class="{{ $activeProjectTeamMember->current_actual_effort >= ($activeProjectTeamMember->daily_expected_effort * count($activeProjectTeamMember->project->getWorkingDaysList($activeProjectTeamMember->project->client->month_start_date, today()->subDay()))) ? 'text-success' : 'text-danger' }}"> {{ $activeProjectTeamMember->current_actual_effort }}
+                                                </div>
+                                            </td>
+                        
+                                            <td>
+                                                <div>
+                                                    <div class="{{$activeProjectTeamMember->velocity >= 1 ? 'text-success' : 'text-danger' }}">
+                                                        {{$activeProjectTeamMember->velocity}}
+                                                    </div>
+                                                </td>
+                        
+                                            <td>
+                                                <div>{{$activeProjectTeamMember->fte}}</div>
+                                            </td>
+                                        </tr>
+                                    @endif
+                                @endforeach
+                            @endif
+                        </thead>              
+                    </table>    
+                </div>
+            @endif
         </div>
     </div>
 </div>    

--- a/resources/views/hr/employees/show.blade.php
+++ b/resources/views/hr/employees/show.blade.php
@@ -30,7 +30,7 @@
             <div class="d-flex"><div class="font-weight-bold fz-24 pl-5 mt-5 mb-3 d-flex justify-content-inline">{{__('Current FTE: ')}}<div class=" ml-1 {{ $employee->user ? ($employee->user->ftes['main'] > 1 ? 'text-success' : 'text-danger') : 'text-secondary'}} font-weight-bold">{{ $employee->user ? $employee->user->ftes['main']  :'NA' }}</div></div>
             <div class="font-weight-bold fz-24 pl-5 mt-5 mb-3 d-flex justify-content-inline">{{__('FTE(AMC): ')}}<div class=" ml-1 {{ $employee->user ? ($employee->user->ftes['amc'] > 1 ? 'text-success' : 'text-danger') : 'text-secondary'}} font-weight-bold">{{ $employee->user ? $employee->user->ftes['amc']  :'NA' }}</div></div></div>
             <canvas class="w-full" id="userDashboardGraph"></canvas>
-            <input type="hidden" id="get_report_data_url" value={{ route('reports.fte.get-report-data', ['user' => $employee->user]) }}>
+            <input type="hidden" id="get_report_data_url" value={{ route('reports.fte.get-report-data', ['user' => $employee->user()->withTrashed()->first()]) }}>
             <div class="font-weight-bold fz-24 pl-5 mt-5 mb-3">Project Details</div>
             <div class="mx-5">
                 <table class="table">


### PR DESCRIPTION
Targets #3445
<!--- 
If there is an open issue, please link to the issue here by replacing [ISSUE_ID]. For eg. #1202
-->

## Description of the changes
<!--- 
Describe your changes or approach in detail. Why these changes are required? What was implemented earlier and what you implemented?
-->
The active project count query is not working correctly for previous employees and also previous employee dashboard and profile details screen is broken for the previous employees

## Breakdown & Estimates 
<!-- 
Please add the action items that you performed and the time they took. For example
- [ ] Action item 1: 2 - 4 hours
- [ ] Action item 2: 4 - 8 hours
-->
- Active project count query fixes for previous employees: 2
- Previous employee dashboard and profile details error fixes: 3

**Expected Time Range:**
5-6 hours

**Actual Time:** 
5 hours

## Feedback Cycle
<!-- 
The number of times feedbacks are given in the PR. This needs to be updated by the reviewer
-->
**Cycle Count: 0**

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [ ] I have added comments on my code changes where required.
