### PR TITLE
#3570 Show revenue by client according to sent conversion rate.

### DIFF
--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -257,19 +257,19 @@ class Invoice extends Model implements Auditable
         $initial = config('invoice.currency_initials');
         switch (strtoupper($this->currency)) {
             case  $initial['usd']:
-                $taotalAmount = $this->getTotalAmountAttribute() * round($conversionRate['USDINR'], 2);
+                $totalAmount = $this->getTotalAmountAttribute() * round($conversionRate['USDINR'], 2);
                 break;
 
             case $initial['eur']:
-                $taotalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDEUR']), 2);
+                $totalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDEUR']), 2);
                 break;
 
             case $initial['swi']:
-                $taotalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDCHF']), 2);
+                $totalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDCHF']), 2);
                 break;
         }
 
-        return $taotalAmount;
+        return $totalAmount;
     }
 
     public function getTermAttribute()

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -268,7 +268,7 @@ class Invoice extends Model implements Auditable
                 $taotalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDCHF']), 2);
                 break;
         }
-        
+
         return $taotalAmount;
     }
 

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -245,8 +245,8 @@ class Invoice extends Model implements Auditable
             return $this->getTotalAmountAttribute();
         }
 
-        if ($this->conversion_rate) {
-            return $this->getTotalAmountAttribute() * $this->conversion_rate;
+        if ($this->sent_conversion_rate) {
+            return $this->getTotalAmountAttribute() * (int)($this->sent_conversion_rate);
         }
 
         return $this->getTotalAmountAttribute() * app(CurrencyServiceContract::class)->getCurrentRatesInINR();

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -246,7 +246,7 @@ class Invoice extends Model implements Auditable
         }
 
         if ($this->sent_conversion_rate) {
-            return $this->getTotalAmountAttribute() * (int)($this->sent_conversion_rate);
+            return $this->getTotalAmountAttribute() * ($this->sent_conversion_rate);
         }
 
         return $this->getTotalAmountAttribute() * app(CurrencyServiceContract::class)->getCurrentRatesInINR();

--- a/Modules/Invoice/Entities/Invoice.php
+++ b/Modules/Invoice/Entities/Invoice.php
@@ -249,7 +249,27 @@ class Invoice extends Model implements Auditable
             return $this->getTotalAmountAttribute() * ($this->sent_conversion_rate);
         }
 
-        return $this->getTotalAmountAttribute() * app(CurrencyServiceContract::class)->getCurrentRatesInINR();
+        if ($this->conversion_rate) {
+            return $this->getTotalAmountAttribute() * ($this->conversion_rate);
+        }
+
+        $conversionRate = app(CurrencyServiceContract::class)->getAllCurrentRatesInINR();
+        $initial = config('invoice.currency_initials');
+        switch (strtoupper($this->currency)) {
+            case  $initial['usd']:
+                $taotalAmount = $this->getTotalAmountAttribute() * round($conversionRate['USDINR'], 2);
+                break;
+
+            case $initial['eur']:
+                $taotalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDEUR']), 2);
+                break;
+
+            case $initial['swi']:
+                $taotalAmount = $this->getTotalAmountAttribute() * round(($conversionRate['USDINR']) / ($conversionRate['USDCHF']), 2);
+                break;
+        }
+        
+        return $taotalAmount;
     }
 
     public function getTermAttribute()

--- a/Modules/Report/Resources/assets/js/app.js
+++ b/Modules/Report/Resources/assets/js/app.js
@@ -107,6 +107,7 @@ function clientWiseRevenueTrendsReport(reportsData) {
 	const labels = reportsData.labels;
 	const currentPeriodTotalRevenue = reportsData.data.total_amount;
 	const averageRevenue = reportsData.data.average_amount;
+	console.log(reportsData.data);
 	const chartData = {
 		labels: labels,
 		datasets: [

--- a/Modules/Report/Resources/assets/js/app.js
+++ b/Modules/Report/Resources/assets/js/app.js
@@ -107,7 +107,6 @@ function clientWiseRevenueTrendsReport(reportsData) {
 	const labels = reportsData.labels;
 	const currentPeriodTotalRevenue = reportsData.data.total_amount;
 	const averageRevenue = reportsData.data.average_amount;
-	console.log(reportsData.data);
 	const chartData = {
 		labels: labels,
 		datasets: [


### PR DESCRIPTION
Targets #3570
<!--- 
If there is an open issue, please link to the issue here by replacing [ISSUE_ID]. For eg. #1202
-->

## Description of the changes
The revenue by client dashboard will now show the revenue according to the conversion rate when the invoice was sent.

## Breakdown & Estimates 
<!-- 
Please add the action items that you performed and the time they took. For example
- [ ] Action item 1: 2 - 4 hours
- [ ] Action item 2: 4 - 8 hours
-->

**Expected Time Range:**

**Actual Time:** 

## Feedback Cycle
<!-- 
The number of times feedbacks are given in the PR. This needs to be updated by the reviewer
-->
**Cycle Count: 0**

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.
