### PR TITLE
Enhanced the Efforts Sync feature to sync the efforts for the desired month.

### DIFF
--- a/Modules/EffortTracking/Http/Controllers/EffortTrackingController.php
+++ b/Modules/EffortTracking/Http/Controllers/EffortTrackingController.php
@@ -33,9 +33,11 @@ class EffortTrackingController extends Controller
      *
      * @param Project $project
      */
-    public function getEffortForProject(Project $project)
+    public function getEffortForProject(Request $request, Project $project)
     {
-        if ($this->service->getEffortForProject($project)) {
+        // TO DO: ADD VALIDATION
+        $syncParams = $request->all();
+        if ($this->service->getEffortForProject($project, $syncParams)) {
             return response()->json(['message' => 'Effort updated successfully'], 200);
         }
 


### PR DESCRIPTION
## Targets #3704 

## Description of the changes

- [ ] Updated the backend flow to update the efforts for the month coming from frontend.
  - [ ] Fetched the `dateDate` from the Request
  - [ ] Used conditional statement to keep the `backDate` either as the date coming from frontend or to the current date.
  - [ ] Based on the `backDate`, update the efforts of the month.
 
- [ ] For manual interpretation during efforts sync, open a popup where the user can select the time
  - [ ] It can include a checkbox to confirm the backdate syncing
  - [ ] Display the date input field if the checkbox is checked
  
- [ ] Send the input date to the backend, using the current ajax request.
- [ ] Code Cleanups
- [ ] Testing the functionality
- [ ] Feedback Implementation
- [ ] UAT Deployment + Testing
- [ ] Production Deployment

## Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The PR title follows this syntax: <#IssueID> \<PR Title>
- [ ] I have linked the issue id in the PR description.
- [ ] I have performed a self-review of my own code.
- [ ] I have added comments on my code changes where required.
