### PR TITLE
Send email to CA

### DIFF
--- a/Modules/Invoice/Config/config.php
+++ b/Modules/Invoice/Config/config.php
@@ -33,6 +33,10 @@ return [
             'email' => env('INVOICE_UNPAID_LIST_EMAIL', 'finance@coloredcow.com'),
             'name' => env('INVOICE_UNPAID_LIST_NAME', 'ColoredCow Finance'),
         ],
+        'finance-team' => [
+            'email' => env('FINANCE_TEAM_EMAIL', 'finance@coloredcow.com'),
+            'name' => env('FINANCE_TEAM_EMAIL_NAME', 'ColoredCow Finance'),
+        ],
     ],
 
     'pending-invoice-mail' => [
@@ -202,8 +206,8 @@ return [
     ],
 
     'ca-email' => [
-        'name' => env('CA_NAME'),
-        'email' => env('CA_EMAIL'),
+        'name' => env('CA_NAME', 'ColoredCow CA'),
+        'email' => env('CA_EMAIL', 'finance@coloredcow.com'),
     ],
     'invoice-google-drive-folder-id' => env('INVOICE_GDRIVE_FOLDER_ID'),
 ];

--- a/Modules/Invoice/Console/SendEmailForUploadedInvoices.php
+++ b/Modules/Invoice/Console/SendEmailForUploadedInvoices.php
@@ -52,7 +52,7 @@ class SendEmailForUploadedInvoices extends Command
             'international' => [
                 'folderName' => 'Invoices - Ex (International)',
                 'folderLink' => null,
-            ]
+            ],
         ];
         foreach ($invoiceFolderNames as $key => $folderDetail) {
             $countryFolderName = $folderDetail['folderName'];

--- a/Modules/Invoice/Console/SendEmailForUploadedInvoices.php
+++ b/Modules/Invoice/Console/SendEmailForUploadedInvoices.php
@@ -48,7 +48,7 @@ class SendEmailForUploadedInvoices extends Command
             'indian' => [
                 'folderName' => 'Invoices - IN (Indian)',
                 'folderLink' => null,
-            ], 
+            ],
             'international' => [
                 'folderName' => 'Invoices - Ex (International)',
                 'folderLink' => null,
@@ -78,7 +78,7 @@ class SendEmailForUploadedInvoices extends Command
         $invoiceCountryFolderId = $this->getOrCreateFolder($service, $countryFolderName, $googleDriveParentFolderId);
         $financialYearFolderId = $this->getOrCreateFolder($service, $financialYearFolderName, $invoiceCountryFolderId);
         $monthFolderId = $this->getOrCreateFolder($service, $monthFolderName, $financialYearFolderId);
-        
+
         return "https://drive.google.com/drive/folders/{$monthFolderId}";
     }
 

--- a/Modules/Invoice/Console/SendEmailForUploadedInvoices.php
+++ b/Modules/Invoice/Console/SendEmailForUploadedInvoices.php
@@ -7,30 +7,24 @@ use Google\Client as GoogleClient;
 use Google\Service\Drive;
 use Google\Service\Drive\DriveFile;
 use Illuminate\Console\Command;
-use Modules\Invoice\Entities\Invoice;
+use Illuminate\Support\Facades\Mail;
+use Modules\Invoice\Emails\SendUploadedInvoicesMail;
 
-class UploadToGDrive extends Command
+class SendEmailForUploadedInvoices extends Command
 {
     /**
      * The console command name.
      *
      * @var string
      */
-    protected $name = 'invoice:upload-to-gdrive';
+    protected $name = 'invoice:email-for-uploaded-invoices';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'This command will upload the invoices to GDrive.';
-
-    /**
-     * The console command signature for arguments.
-     *
-     * @var string
-     */
-    protected $signature = 'invoice:upload-to-gdrive {startDate?} {endDate?}';
+    protected $description = 'This command will send email to CA for the last month uploaded invoices';
 
     /**
      * Create a new command instance.
@@ -49,37 +43,29 @@ class UploadToGDrive extends Command
      */
     public function handle()
     {
-        $startDate = $this->argument('startDate')
-            ? Carbon::parse($this->argument('startDate'))
-            : Carbon::now()->subMonth()->startOfMonth();
-
-        $endDate = $this->argument('endDate')
-            ? Carbon::parse($this->argument('endDate'))
-            : Carbon::now()->subMonth()->endOfMonth();
-
-        $this->info('Uploading invoices from ' . $startDate->toDateString() . ' to ' . $endDate->toDateString());
-
-        $invoices = Invoice::whereBetween('sent_on', [$startDate, $endDate])->get();
-        foreach ($invoices as $invoice) {
-            if (! $invoice->file_path) {
-                continue;
-            }
-            $monthFolderName = $invoice->sent_on->format('M Y');
-            $financialYear = $this->getFinancialYear($invoice->sent_on);
-            $fileLocalPath = storage_path('app/' . $invoice->file_path);
-            $isIndianInvoice = substr($invoice->invoice_number, 0, 2) == 'IN';
-            $googleDriveLink = $this->uploadFileToGoogleDrive($fileLocalPath, $monthFolderName, $financialYear, $isIndianInvoice);
-
-            // Update the google_drive_link column of the invoice
-            $invoice->google_drive_link = $googleDriveLink;
-            $invoice->save();
-
-            $this->info("Updated google_drive_link for invoice ID {$invoice->id}");
-            sleep(1);
+        $previousMonthDate = Carbon::now()->subMonth()->startOfMonth();
+        $invoiceFolderNames = [
+            'indian' => [
+                'folderName' => 'Invoices - IN (Indian)',
+                'folderLink' => null,
+            ], 
+            'international' => [
+                'folderName' => 'Invoices - Ex (International)',
+                'folderLink' => null,
+            ]
+        ];
+        foreach ($invoiceFolderNames as $key => $folderDetail) {
+            $countryFolderName = $folderDetail['folderName'];
+            $monthFolderName = $previousMonthDate->format('M Y');
+            $financialYear = $this->getFinancialYear($previousMonthDate);
+            $googleDriveLink = $this->getFolderLink($monthFolderName, $financialYear, $countryFolderName);
+            $invoiceFolderNames[$key]['folderLink'] = $googleDriveLink;
         }
+
+        Mail::send(new SendUploadedInvoicesMail($invoiceFolderNames));
     }
 
-    private function uploadFileToGoogleDrive($filePath, $monthFolderName, $financialYearFolderName, $isIndianInvoice)
+    private function getFolderLink($monthFolderName, $financialYearFolderName, $countryFolderName)
     {
         $googleDriveParentFolderId = config('invoice.invoice-google-drive-folder-id');
 
@@ -88,28 +74,12 @@ class UploadToGDrive extends Command
         $client->addScope(Drive::DRIVE);
         $client->setAccessType('offline');
         $service = new Drive($client);
-        $countryFolderName = $isIndianInvoice ? 'Invoices - IN (Indian)' : 'Invoices - Ex (International)';
 
         $invoiceCountryFolderId = $this->getOrCreateFolder($service, $countryFolderName, $googleDriveParentFolderId);
         $financialYearFolderId = $this->getOrCreateFolder($service, $financialYearFolderName, $invoiceCountryFolderId);
         $monthFolderId = $this->getOrCreateFolder($service, $monthFolderName, $financialYearFolderId);
-        $content = file_get_contents($filePath);
-        $fileName = basename($filePath);
-        $fileMetadata = new DriveFile([
-            'name' => $fileName,
-            'parents' => [$monthFolderId],
-        ]);
-
-        $uploadedFile = $service->files->create($fileMetadata, [
-            'data' => $content,
-            'mimeType' => mime_content_type($filePath),
-            'uploadType' => 'multipart',
-            'fields' => 'id, webViewLink, webContentLink',
-        ]);
-
-        $this->info('Uploaded invoice: ' . $fileName . ' to folder: ' . $countryFolderName . '/' . $monthFolderName);
-
-        return $uploadedFile->webViewLink;
+        
+        return "https://drive.google.com/drive/folders/{$monthFolderId}";
     }
 
     private function getOrCreateFolder($service, $folderName, $parentFolderId)

--- a/Modules/Invoice/Emails/SendUploadedInvoicesMail.php
+++ b/Modules/Invoice/Emails/SendUploadedInvoicesMail.php
@@ -17,7 +17,7 @@ class SendUploadedInvoicesMail extends Mailable
      *
      * @return void
      */
-    public function __construct(Array $invoicesFolderDetails)
+    public function __construct(array $invoicesFolderDetails)
     {
         $this->invoicesFolderDetails = $invoicesFolderDetails;
     }

--- a/Modules/Invoice/Emails/SendUploadedInvoicesMail.php
+++ b/Modules/Invoice/Emails/SendUploadedInvoicesMail.php
@@ -38,7 +38,7 @@ class SendUploadedInvoicesMail extends Mailable
             ->view('invoice::mail.uploaded-invoice-folder-details-mail')
             ->with([
                 'invoicesFolderDetails' => $this->invoicesFolderDetails,
-                'monthYear' => $monthYear
+                'monthYear' => $monthYear,
             ]);
     }
 }

--- a/Modules/Invoice/Emails/SendUploadedInvoicesMail.php
+++ b/Modules/Invoice/Emails/SendUploadedInvoicesMail.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modules\Invoice\Emails;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class SendUploadedInvoicesMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    protected $invoicesFolderDetails;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(Array $invoicesFolderDetails)
+    {
+        $this->invoicesFolderDetails = $invoicesFolderDetails;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $monthYear = now()->subMonth()->format('F Y');
+
+        return $this->to(config('invoice.ca-email.email'))
+            ->from(config('invoice.mail.finance-team.email'))
+            ->cc(config('invoice.ca-email.email'))
+            ->subject('Invoice details for ' . $monthYear)
+            ->view('invoice::mail.uploaded-invoice-folder-details-mail')
+            ->with([
+                'invoicesFolderDetails' => $this->invoicesFolderDetails,
+                'monthYear' => $monthYear
+            ]);
+    }
+}

--- a/Modules/Invoice/Resources/views/mail/uploaded-invoice-folder-details-mail.blade.php
+++ b/Modules/Invoice/Resources/views/mail/uploaded-invoice-folder-details-mail.blade.php
@@ -1,0 +1,12 @@
+<div>
+    <p>Dear {{ config('invoice.ca-email.name') }}</p>
+    <p>Please find the invoices for the month of {{ $monthYear }} for GSTR1 filing.</p>
+    <div>
+        <p>1. Indian Invoices <a href="{{ $invoicesFolderDetails['indian']['folderLink'] }}">{{ $invoicesFolderDetails['indian']['folderLink'] }}</a></p>
+        <p>2. International invoices <a href="{{ $invoicesFolderDetails['international']['folderLink'] }}">{{ $invoicesFolderDetails['indian']['folderLink'] }}</a></p>
+    </div>
+    <br>
+    <p>Let me know if you have any questions.</p>
+    <p>Thanks</p>
+    <p>Mohit</p>
+</div>

--- a/Modules/Invoice/Resources/views/mail/uploaded-invoice-folder-details-mail.blade.php
+++ b/Modules/Invoice/Resources/views/mail/uploaded-invoice-folder-details-mail.blade.php
@@ -3,7 +3,7 @@
     <p>Please find the invoices for the month of {{ $monthYear }} for GSTR1 filing.</p>
     <div>
         <p>1. Indian Invoices <a href="{{ $invoicesFolderDetails['indian']['folderLink'] }}">{{ $invoicesFolderDetails['indian']['folderLink'] }}</a></p>
-        <p>2. International invoices <a href="{{ $invoicesFolderDetails['international']['folderLink'] }}">{{ $invoicesFolderDetails['indian']['folderLink'] }}</a></p>
+        <p>2. International invoices <a href="{{ $invoicesFolderDetails['international']['folderLink'] }}">{{ $invoicesFolderDetails['international']['folderLink'] }}</a></p>
     </div>
     <br>
     <p>Let me know if you have any questions.</p>

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Modules\HR\Console\JobExpiredEmailToHr;
 use Modules\Invoice\Console\SeedLoanInstallmentForMonth;
+use Modules\Invoice\Console\SendEmailForUploadedInvoices;
 use Modules\Invoice\Console\UploadToGDrive;
 use Modules\Project\Console\DeliveryReportReminder;
 use Modules\Project\Console\EndedProject;
@@ -35,6 +36,7 @@ class Kernel extends ConsoleKernel
         JobExpiredEmailToHr::class,
         SeedLoanInstallmentForMonth::class,
         UploadToGDrive::class,
+        SendEmailForUploadedInvoices::class,
         // QuarterlyReviewSystemForEmployee::class, //This line will be commented for some time. After the feature is completed, it will be uncommented.
 
     ];
@@ -69,6 +71,7 @@ class Kernel extends ConsoleKernel
 
         if (env('APP_ENV') == 'production') {
             $schedule->command('invoice:upload-to-gdrive')->timezone(config('constants.timezone.indian'))->monthlyOn(1, '01:00');
+            $schedule->command('invoice:email-for-uploaded-invoices')->timezone(config('constants.timezone.indian'))->monthlyOn(1, '08:00');
         }
     }
 


### PR DESCRIPTION
### Changes
- Add a cron to send invoice folder link to CA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration for the finance team email settings.
	- Added a console command to send emails with links to uploaded invoices from the previous month.
	- Created a new email class for sending details about uploaded invoices.
	- Enhanced the email template to include personalized greetings and links to invoice folders.

- **Bug Fixes**
	- Removed a conditional check that previously prevented uploads on a specific date, ensuring invoices can now be uploaded as intended.

- **Chores**
	- Scheduled the new email command to run monthly for improved automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->