### PR TITLE
Currency API Layer Error Handling

### DIFF
--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -87,6 +87,7 @@ class CurrencyService implements CurrencyServiceContract
     {
         if (! config('services.currencylayer.access_key')) {
             Log::warning('CurrencyLayer API key missing. Using default rate.');
+
             return [
                 'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2),
             ];
@@ -114,7 +115,6 @@ class CurrencyService implements CurrencyServiceContract
             Log::error('Unexpected error fetching all exchange rates: ' . $e->getMessage());
         }
 
-        // fallback if API fails
         return [
             'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2),
         ];

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -18,7 +18,7 @@ class CurrencyService implements CurrencyServiceContract
         $this->setClient();
     }
 
-    protected function setClient(): void
+    public function setClient()
     {
         $headers = [
             'apikey' => config('services.currencylayer.access_key'),
@@ -54,6 +54,7 @@ class CurrencyService implements CurrencyServiceContract
     {
         if (! config('services.currencylayer.access_key')) {
             Log::warning('CurrencyLayer API key missing. Using default rate.');
+
             return round(config('services.currencylayer.default_rate', 83.00), 2);
         }
 
@@ -79,7 +80,7 @@ class CurrencyService implements CurrencyServiceContract
         } catch (\Throwable $e) {
             Log::error('Unexpected error fetching exchange rate: ' . $e->getMessage());
         }
-        
+
         return round(config('services.currencylayer.default_rate', 83.00), 2);
     }
 

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -27,14 +27,14 @@ class CurrencyService implements CurrencyServiceContract
         $this->client = new Client([
             'base_uri' => 'https://api.apilayer.com',
             'headers'  => $headers,
-            'timeout'  => 10, // seconds
+            'timeout'  => 10,
             'connect_timeout' => 5,
         ]);
     }
 
     public function getCurrentRatesInINR()
     {
-        $seconds = 4 * 60 * 60; // 4 hours
+        $seconds = 1 * 60 * 60 * 4;
 
         return Cache::remember('current_usd_rates', $seconds, function () {
             return $this->fetchExchangeRateInINR();
@@ -43,7 +43,7 @@ class CurrencyService implements CurrencyServiceContract
 
     public function getAllCurrentRatesInINR()
     {
-        $seconds = 4 * 60 * 60;
+        $seconds =  1 * 60 * 60 * 4;
 
         return Cache::remember('all_current_usd_rates', $seconds, function () {
             return $this->fetchAllExchangeRateInINR();

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -3,8 +3,8 @@
 namespace Modules\Invoice\Services;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Modules\Invoice\Contracts\CurrencyServiceContract;

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -43,7 +43,7 @@ class CurrencyService implements CurrencyServiceContract
 
     public function getAllCurrentRatesInINR()
     {
-        $seconds =  1 * 60 * 60 * 4;
+        $seconds = 1 * 60 * 60 * 4;
 
         return Cache::remember('all_current_usd_rates', $seconds, function () {
             return $this->fetchAllExchangeRateInINR();
@@ -52,7 +52,7 @@ class CurrencyService implements CurrencyServiceContract
 
     private function fetchExchangeRateInINR()
     {
-        if (!config('services.currencylayer.access_key')) {
+        if (! config('services.currencylayer.access_key')) {
             Log::warning('CurrencyLayer API key missing. Using default rate.');
             return round(config('services.currencylayer.default_rate', 83.00), 2);
         }
@@ -79,17 +79,16 @@ class CurrencyService implements CurrencyServiceContract
         } catch (\Throwable $e) {
             Log::error('Unexpected error fetching exchange rate: ' . $e->getMessage());
         }
-
-        // fallback to default value if everything fails
+        
         return round(config('services.currencylayer.default_rate', 83.00), 2);
     }
 
     private function fetchAllExchangeRateInINR()
     {
-        if (!config('services.currencylayer.access_key')) {
+        if (! config('services.currencylayer.access_key')) {
             Log::warning('CurrencyLayer API key missing. Using default rate.');
             return [
-                'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2)
+                'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2),
             ];
         }
 
@@ -117,7 +116,7 @@ class CurrencyService implements CurrencyServiceContract
 
         // fallback if API fails
         return [
-            'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2)
+            'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2),
         ];
     }
 }

--- a/Modules/Invoice/Services/CurrencyService.php
+++ b/Modules/Invoice/Services/CurrencyService.php
@@ -3,7 +3,10 @@
 namespace Modules\Invoice\Services;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ConnectException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Modules\Invoice\Contracts\CurrencyServiceContract;
 
 class CurrencyService implements CurrencyServiceContract
@@ -15,21 +18,23 @@ class CurrencyService implements CurrencyServiceContract
         $this->setClient();
     }
 
-    public function setClient()
+    protected function setClient(): void
     {
-        $headers = $headers = [
+        $headers = [
             'apikey' => config('services.currencylayer.access_key'),
         ];
+
         $this->client = new Client([
-            // 'base_uri' => 'http://apilayer.net/api',    //This is old API URL
-            'base_uri' => 'https://api.apilayer.com',  // This is new API created from https://apilayer.com/marketplace/currency_data-api
-            'headers' => $headers,
+            'base_uri' => 'https://api.apilayer.com',
+            'headers'  => $headers,
+            'timeout'  => 10, // seconds
+            'connect_timeout' => 5,
         ]);
     }
 
     public function getCurrentRatesInINR()
     {
-        $seconds = 1 * 60 * 60 * 4;
+        $seconds = 4 * 60 * 60; // 4 hours
 
         return Cache::remember('current_usd_rates', $seconds, function () {
             return $this->fetchExchangeRateInINR();
@@ -38,7 +43,7 @@ class CurrencyService implements CurrencyServiceContract
 
     public function getAllCurrentRatesInINR()
     {
-        $seconds = 1 * 60 * 60 * 4;
+        $seconds = 4 * 60 * 60;
 
         return Cache::remember('all_current_usd_rates', $seconds, function () {
             return $this->fetchAllExchangeRateInINR();
@@ -47,36 +52,72 @@ class CurrencyService implements CurrencyServiceContract
 
     private function fetchExchangeRateInINR()
     {
-        if (! config('services.currencylayer.access_key')) {
-            return round(config('services.currencylayer.default_rate'), 2);
+        if (!config('services.currencylayer.access_key')) {
+            Log::warning('CurrencyLayer API key missing. Using default rate.');
+            return round(config('services.currencylayer.default_rate', 83.00), 2);
         }
 
-        $response = $this->client->get('currency_data/live', [
-            'query' => [
-                'access_key' => config('services.currencylayer.access_key'),
-                'currencies' => 'INR',
-            ],
-        ]);
+        try {
+            $response = $this->client->get('currency_data/live', [
+                'query' => [
+                    'currencies' => 'INR',
+                    'source'     => 'USD',
+                ],
+            ]);
 
-        $data = json_decode($response->getBody()->getContents(), true);
+            $data = json_decode($response->getBody()->getContents(), true);
 
-        return round($data['quotes']['USDINR'], 2);
+            if (empty($data) || empty($data['quotes']['USDINR'])) {
+                throw new \Exception('Invalid API response structure.');
+            }
+
+            return round($data['quotes']['USDINR'], 2);
+        } catch (ConnectException $e) {
+            Log::error('Currency API connection failed: ' . $e->getMessage());
+        } catch (RequestException $e) {
+            Log::error('Currency API request error: ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            Log::error('Unexpected error fetching exchange rate: ' . $e->getMessage());
+        }
+
+        // fallback to default value if everything fails
+        return round(config('services.currencylayer.default_rate', 83.00), 2);
     }
 
     private function fetchAllExchangeRateInINR()
     {
-        if (! config('services.currencylayer.access_key')) {
-            return round(config('services.currencylayer.default_rate'), 2);
+        if (!config('services.currencylayer.access_key')) {
+            Log::warning('CurrencyLayer API key missing. Using default rate.');
+            return [
+                'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2)
+            ];
         }
 
-        $response = $this->client->get('currency_data/live', [
-            'query' => [
-                'access_key' => config('services.currencylayer.access_key'),
-            ],
-        ]);
+        try {
+            $response = $this->client->get('currency_data/live', [
+                'query' => [
+                    'source' => 'USD',
+                ],
+            ]);
 
-        $data = json_decode($response->getBody()->getContents(), true);
+            $data = json_decode($response->getBody()->getContents(), true);
 
-        return $data['quotes'];
+            if (empty($data) || empty($data['quotes'])) {
+                throw new \Exception('Invalid API response structure.');
+            }
+
+            return $data['quotes'];
+        } catch (ConnectException $e) {
+            Log::error('Currency API connection failed: ' . $e->getMessage());
+        } catch (RequestException $e) {
+            Log::error('Currency API request error: ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            Log::error('Unexpected error fetching all exchange rates: ' . $e->getMessage());
+        }
+
+        // fallback if API fails
+        return [
+            'USDINR' => round(config('services.currencylayer.default_rate', 83.00), 2)
+        ];
     }
 }


### PR DESCRIPTION
Due to the refactoring of currenlylayer API, the regular invoice workflows in portal are failing. As the part of a temporary fix, I have enabled sufficient try catch blogs, for better logging and handling of errors received in API. Even when the API fails, it won't crash the entire page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of currency conversion with robust error handling and safe fallbacks.
  - Prevents failures during network or API issues by returning a default INR rate when needed.
  - Handles missing API key gracefully with non-blocking behavior and clear logging.

- Chores
  - Updated external currency API endpoint and client timeouts for more stable responses.
  - Standardized response validation and logging for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->