### PR TITLE
fix(prospect): format proposal_sent_date correctly in edit form

### DIFF
--- a/Modules/Prospect/Resources/views/subviews/edit-prospect-details.blade.php
+++ b/Modules/Prospect/Resources/views/subviews/edit-prospect-details.blade.php
@@ -58,7 +58,7 @@
                     <div class="form-group col-md-5">
                         <label for="proposal_sent_date">Proposal Sent Date</label>
                         <input type="date" class="form-control" name="proposal_sent_date" id="proposal_sent_date"
-                            value="{{ $prospect->proposal_sent_date }}">
+                            value="{{ $prospect->proposal_sent_date ? $prospect->proposal_sent_date->format('Y-m-d') : '' }}">
                     </div>
                     <div class="form-group offset-md-1 col-md-5">
                         <label for="domain">{{ __('Domain') }}</label>


### PR DESCRIPTION
## Problem

When editing a prospect, the **Proposal Sent Date** field appears blank even though a date was previously saved. This causes the date to be deleted on update.

## Root Cause

The `proposal_sent_date` field in `Prospect.php` has a `datetime:Y-m-d` cast, which returns a **Carbon object** instead of a plain string. When rendered in Blade via `{{ $prospect->proposal_sent_date }}`, Carbon's `__toString()` outputs the full datetime (`2024-03-14 00:00:00`). The `<input type="date">` element requires exactly `YYYY-MM-DD` format — the trailing time portion causes the browser to reject the value and render the field as blank.

## Fix

Explicitly format the Carbon object in the Blade template:

```blade
{{ $prospect->proposal_sent_date ? $prospect->proposal_sent_date->format('Y-m-d') : '' }}
```

**File changed:** `Modules/Prospect/Resources/views/subviews/edit-prospect-details.blade.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Proposal Sent Date field to gracefully handle missing dates and display formatted dates when available, eliminating potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->