### PR TITLE
Rename branch references from master/release to develop/main

### DIFF
--- a/.claude/agents/implementation-executor.md
+++ b/.claude/agents/implementation-executor.md
@@ -32,9 +32,9 @@ If no plan is provided or you cannot locate one, use `AskUserQuestion` to ask th
 - If existing, ask for the branch name.
 
 **If creating a new branch:**
-1. Identify the default branch (`master` for this project).
-2. Switch to the default branch: `git checkout master`
-3. Pull latest: `git pull origin master`
+1. Identify the default branch (`develop` for this project).
+2. Switch to the default branch: `git checkout develop`
+3. Pull latest: `git pull origin develop`
 4. Create and switch to the new branch following the project's naming convention:
    - Features: `feature/{issue-id}/{short-description}`
    - Bug fixes: `bugfix/{issue-id}/{short-description}`
@@ -79,7 +79,7 @@ After **all tasks across all phases** are complete:
 
 ### Step 5: Create a Pull Request
 
-Use `gh pr create` to open a PR targeting `master`:
+Use `gh pr create` to open a PR targeting `develop`:
 
 ```bash
 gh pr create --title "#<issue-number> <Short description>" --body "$(cat <<'EOF'
@@ -131,7 +131,7 @@ gh pr edit <pr-number> --add-assignee "$CURRENT_USER"
 
 ## Important Guidelines
 
-- **Follow all Git Rules from CLAUDE.md** — never commit to `master` or `release` directly, stage specific files, conventional commits, etc.
+- **Follow all Git Rules from CLAUDE.md** — never commit to `develop` or `main` directly, stage specific files, conventional commits, etc.
 - **Follow existing patterns:** This project uses nwidart/laravel-modules (modular architecture), service layer pattern, Spatie permissions, and Blade + Vue.js views. Match the existing code style and architecture.
 - **Never skip pre-commit hooks** — fix lint/format issues rather than bypassing them. Husky + lint-staged enforces PHP-CS-Fixer and ESLint on staged files.
 - **Module-specific assets:** If creating new JS/CSS for a module, ensure `webpack.mix.js` has the appropriate entry.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,7 +2,7 @@ name: Coding Standards
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [develop]
 
 jobs:
   ColoredCowLaravelCI:

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -3,9 +3,9 @@ name: Integration testing
 # Controls when the action will run.
 on:
   push:
-    branches: [master]
+    branches: [develop]
   pull_request:
-    branches: [master]
+    branches: [develop]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -1,7 +1,7 @@
 name: Production Deployment
 on:
   push:
-    branches: [release]
+    branches: [main]
 
 jobs:
   build:
@@ -32,7 +32,7 @@ jobs:
 
           echo "Pulling latest code"
           git checkout -f
-          git pull origin release
+          git pull origin main
           php artisan migrate --force
 
           echo "Running composer"

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -1,7 +1,7 @@
 name: Staging Deployment
 on:
   push:
-    branches: [master]
+    branches: [develop]
 
 jobs:
   build:
@@ -33,7 +33,7 @@ jobs:
 
           echo "Pulling latest code"
           git checkout -f
-          git pull origin master
+          git pull origin develop
           php artisan migrate
 
           echo "Running composer"

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -3,9 +3,9 @@ name: Unit testing
 # Controls when the action will run.
 on:
   push:
-    branches: [master]
+    branches: [develop]
   pull_request:
-    branches: [master]
+    branches: [develop]
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,12 +82,12 @@ Uses **Spatie Laravel Permission** for role-based access control (RBAC). Authori
 
 ## Branch Naming Convention
 
-- `feature/{issue-id}/{description}` — New features (base: `master`)
-- `bugfix/{issue-id}/{description}` — Bug fixes (base: `master`)
-- `hotfix/{description}` — Urgent production fixes (base: `release`)
-- `doc/{description}` — Documentation changes (base: `master`)
+- `feature/{issue-id}/{description}` — New features (base: `develop`)
+- `bugfix/{issue-id}/{description}` — Bug fixes (base: `develop`)
+- `hotfix/{description}` — Urgent production fixes (base: `main`)
+- `doc/{description}` — Documentation changes (base: `develop`)
 
-Production branch is `release`. Development branch is `master`.
+Production branch is `main`. Development branch is `develop`.
 
 ## Naming Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ When contributing to this repository, please first discuss the change you wish t
 
 1. Fork this repository. Read about [how to fork a repository](https://help.github.com/articles/fork-a-repo/).
 
-2. For every contribution, create a new branch. A branch name must follow the format `feature/{issueID}/{description}` or `bugfix/{issueID}/{description}`.
+2. For every contribution, create a new branch. A branch name must follow the format `feature/{issueID}/{description}`, `bugfix/{issueID}/{description}`, `hotfix/{description}`, or `doc/{description}`.
 
         > git branch feature/497/billing-calculation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@ When contributing to this repository, please first discuss the change you wish t
 
 1. Fork this repository. Read about [how to fork a repository](https://help.github.com/articles/fork-a-repo/).
 
-2. For every contribution, create a new branch. A branch name must follow the format `issueID-issue-info`.
+2. For every contribution, create a new branch. A branch name must follow the format `feature/{issueID}/{description}` or `bugfix/{issueID}/{description}`.
 
-        > git branch 497-billing-calculation
+        > git branch feature/497/billing-calculation
 
 3. Make brief and clear commit messages.
         

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![GitHub issues](https://img.shields.io/github/issues/coloredcow/portal)
 [![codecov](https://codecov.io/gh/ColoredCow/portal/graph/badge.svg?token=LO38hOYgBT)](https://codecov.io/gh/ColoredCow/portal)
-[![Coding Standards](https://github.com/coloredcow/portal/actions/workflows/coding-standards.yml/badge.svg?branch=master)](https://github.com/coloredcow/portal/actions/workflows/coding-standards.yml)
+[![Coding Standards](https://github.com/coloredcow/portal/actions/workflows/coding-standards.yml/badge.svg?branch=develop)](https://github.com/coloredcow/portal/actions/workflows/coding-standards.yml)
 [![Staging Deployment](https://github.com/ColoredCow/portal/actions/workflows/staging-deployment.yml/badge.svg)](https://github.com/ColoredCow/portal/actions/workflows/staging-deployment.yml)
 
 ### Introduction

--- a/docs/branch-naming-convention.md
+++ b/docs/branch-naming-convention.md
@@ -18,7 +18,7 @@
     <tr>
       <td></td>
       <td>develop</td>
-      <td>Base branch should always be main </td>
+      <td>Integration branch for features, bugfixes, and documentation.</td>
     </tr>
     <tr>
       <td>Temporary</td>

--- a/docs/branch-naming-convention.md
+++ b/docs/branch-naming-convention.md
@@ -12,33 +12,33 @@
   <tbody>
     <tr>
       <td>Code Flow</td>
-      <td>release</td>
+      <td>main</td>
       <td>This is the main branch for production.</td>
     </tr>
     <tr>
       <td></td>
-      <td>master</td>
-      <td>Base branch should always be release </td>
+      <td>develop</td>
+      <td>Base branch should always be main </td>
     </tr>
     <tr>
       <td>Temporary</td>
       <td>feature</td>
-      <td>Base branch should always be master.</td>
+      <td>Base branch should always be develop.</td>
     </tr>
     <tr>
       <td></td>
       <td>bugfix</td>
-      <td>Base branch should always be master.</td>
+      <td>Base branch should always be develop.</td>
     </tr>
     <tr>
       <td></td>
       <td>hotfix</td>
-      <td>Base branch should be release.</td>
+      <td>Base branch should be main.</td>
     </tr>
     <tr>
       <td></td>
       <td>doc</td>
-      <td>Base branch should always be master.</td>
+      <td>Base branch should always be develop.</td>
     </tr>
   </tbody>
 </table>
@@ -53,11 +53,11 @@ In this convention, the branches are divided into two categories:
 ### Code Flow Branches
 These branches which we expect to be permanently available on the repository follow the flow of code changes starting from development until the production.
 
-#### 1. Master
-All new pull requests related to features and bug fixes shoulb be merged into this branch after code reviews. Resolving developer codes conflicts should be done as early as here.
+#### 1. Develop
+All new pull requests related to features and bug fixes should be merged into this branch after code reviews. Resolving developer code conflicts should be done as early as here.
 
-#### 2. Release
-This is the main branch for production. Nothing should be directly pushed into this branch except for the hot-fix errors and the master branch after the complete testing of the issues or bug fixes.
+#### 2. Main
+This is the main branch for production. Nothing should be directly pushed into this branch except for the hot-fix errors and the develop branch after the complete testing of the issues or bug fixes.
 
 ### Temporary Branches
 As the name implies, these are disposable branches that can be created and deleted by need of the developer or deployer.
@@ -82,7 +82,7 @@ Examples:
 - bugfix/21/mail-not-sending
 
 #### 3. Hot Fix
-If there is an issue in the release branch then it needs to be  fixed immediately, then that issue should be created as a Hotfix. The hotfix branch should be pulled from the release branch.
+If there is an issue in the main branch then it needs to be fixed immediately, then that issue should be created as a Hotfix. The hotfix branch should be pulled from the main branch.
 
 Examples:
 - hotfix/disable-endpoint-zero-day-exploit

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,5 @@
 ## Deployment Guidelines :mag_right:
-Portal uses GitHub action to deploy the portal on staging server.
+Portal uses GitHub Actions to deploy the portal on staging server.
 
 ## Environment setup for auto deployment
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ Portal uses GitHub action to deploy the portal on staging server.
 ## Environment setup for auto deployment
 
 ### Staging Deployment setup
-Staging builds are configured using GitHub Actions. The file `.github/workflows/deploy-staging.yml` contains the commands to deploy the portal. Production builds happen when code is pushed to `master` branch.
+Staging builds are configured using GitHub Actions. The file `.github/workflows/staging-deployment.yml` contains the commands to deploy the portal. Staging builds happen when code is pushed to `develop` branch.
 
 To set up the deployment workflow, follow the steps below.
 
@@ -51,7 +51,7 @@ To set up the deployment workflow, follow the steps below.
 For more information, check out [staging-deployment.yml](../.github/workflows/staging-deployment.yml).
 
 ### Production Deployment setup
-Production builds are configured using GitHub Actions. The file `.github/workflows/deploy-staging.yml` contains the commands to deploy the portal. Production builds happen when new releases are published. For example `v1.1.2`.
+Production builds are configured using GitHub Actions. The file `.github/workflows/production-deployment.yml` contains the commands to deploy the portal. Production builds happen when code is pushed to `main` branch.
 
 To set up the production deployment workflow, follow the same steps as staging. Make sure to update the keys and environment variables accordingly.
 
@@ -64,16 +64,16 @@ For more information, check out [production-deployment.yml](../.github/workflows
 **Pre-requisites:**
 You need to have permission to deploy on the staging Environment. If you don't have the required access, please reach out to the Infra team for your deployment approval access
 
-1. Raise the PR against the `master` branch.
-2. Get the PR reviewed and merged into the `master` branch.
+1. Raise the PR against the `develop` branch.
+2. Get the PR reviewed and merged into the `develop` branch.
 3. Go to [Staging Deployment GitHub action](https://github.com/ColoredCow/portal/actions/workflows/staging-deployment.yml)
 4. Approve the deployment.
 
 ### Production Deployment
 **Pre-requisites:**
-You need to have permission to deploy on the staging Environment. If you don't have the required access, please reach out to the Infra team for your deployment approval access
+You need to have permission to deploy on the Production Environment. If you don't have the required access, please reach out to the Infra team for your deployment approval access
 
-1. Raise the PR against the `release` branch.
-2. Get the PR reviewed and merged into the `release` branch.
+1. Raise the PR against the `main` branch.
+2. Get the PR reviewed and merged into the `main` branch.
 3. Go to [Production Deployment GitHub action](https://github.com/ColoredCow/portal/actions/workflows/production-deployment.yml)
 4. Approve the deployment.

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@
 
 ## Working in the `portal` repo
 1. Push your local changes to Github.
-    * Once you have updated you master branch with the latest changes, you can follow these steps to create a new branch, make changes, and push it to GitHub.
+    * Once you have updated your develop branch with the latest changes, you can follow these steps to create a new branch, make changes, and push it to GitHub.
 
         ```sh
         git checkout -b branchname     # create a branch where you will commit your changes

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,7 +102,7 @@ Before you start following the guidelines, make sure to go through the [prerequi
 
    2. Database configurations
 
-   - Create a database in your local server. If you skipped it on the prerequisites guideline, you can check it out on point 3.4 of the prerequisites. [Go to prerequisites](https://github.com/ColoredCow/portal/blob/master/docs/prerequisites.md)
+   - Create a database in your local server. If you skipped it on the prerequisites guideline, you can check it out on point 3.4 of the prerequisites. [Go to prerequisites](https://github.com/ColoredCow/portal/blob/develop/docs/prerequisites.md)
    - Configure your Laravel app with the right DB settings as mentioned below.
    - Read [the story](https://docs.google.com/document/d/1sWj0F2uXkSE9oHBkChv-yC2L7P7qazsPY5sNPC1PIp4/edit) about how the team discussed which video should be in the docs
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -180,7 +180,7 @@ This project uses Laravel Modules, so a basic understanding of the commands is r
 
 This project uses Cypress for automated testing, so a basic understanding of the writing test cases is recommended:
 
-- [Introduction to Cypress](https://github.com/ColoredCow/portal/blob/master/docs/testing.md)
+- [Introduction to Cypress](https://github.com/ColoredCow/portal/blob/develop/docs/testing.md)
 - [Writing Your First Test](https://docs.cypress.io/guides/getting-started/writing-your-first-test)
 - [Testing Your App](https://docs.cypress.io/guides/getting-started/testing-your-app#Step-1-Start-your-server)
 


### PR DESCRIPTION
## Summary
- Updated all 5 GitHub Actions workflow files to trigger on `develop` (instead of `master`) and `main` (instead of `release`)
- Updated deployment scripts to pull from `develop`/`main` instead of `master`/`release`
- Updated all documentation (CLAUDE.md, branch-naming-convention, deployment, development, installation, prerequisites, CONTRIBUTING, README) to reference the new branch names
- Updated `.claude/agents/implementation-executor.md` to use `develop` as the default branch

## Files changed (14)
| Category | Files |
|----------|-------|
| CI/CD Workflows | `coding-standards.yml`, `unit-testing.yml`, `integration-testing.yml`, `staging-deployment.yml`, `production-deployment.yml` |
| Documentation | `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/branch-naming-convention.md`, `docs/deployment.md`, `docs/development.md`, `docs/installation.md`, `docs/prerequisites.md` |
| Claude Agents | `.claude/agents/implementation-executor.md` |

## Test plan
- [ ] Verify CI workflows trigger correctly on pushes/PRs to `develop`
- [ ] Verify production deployment triggers on push to `main`
- [ ] Verify staging deployment SSH script pulls from `develop`
- [ ] Verify production deployment SSH script pulls from `main`
- [ ] Grep `.github/workflows/` for any remaining `master` or `release` branch references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow automation and deployment pipelines to align with reorganized branching strategy.
  * Reconfigured automated testing, code standards verification, and deployment triggers across development and production environments.
  * Updated contribution guidelines and internal documentation to reflect new branch naming conventions and workflow procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->