### PR TITLE
#3814 Fix opportunity status field save and display bug

### DIFF
--- a/.claude/agents/implementation-executor.md
+++ b/.claude/agents/implementation-executor.md
@@ -32,8 +32,8 @@ If no plan is provided or you cannot locate one, use `AskUserQuestion` to ask th
 - If existing, ask for the branch name.
 
 **If creating a new branch:**
-1. Identify the default branch (`develop` for this project).
-2. Switch to the default branch: `git checkout develop`
+1. Identify the development branch (`develop` for this project).
+2. Switch to the development branch: `git checkout develop`
 3. Pull latest: `git pull origin develop`
 4. Create and switch to the new branch following the project's naming convention:
    - Features: `feature/{issue-id}/{short-description}`

--- a/Modules/HR/Config/config.php
+++ b/Modules/HR/Config/config.php
@@ -68,7 +68,7 @@ return [
         'Draft' => 'draft',
         'Published' => 'published',
         // 'archived' => 'Archived',
-        'Closed' => 'draft',
+        'Closed' => 'closed',
         'Pending Review' => 'pending-review',
     ],
 
@@ -78,6 +78,7 @@ return [
         'draft' => 'draft',
         // 'archived' => 'archived',
         'pending-review' => 'pending',
+        'closed' => 'draft',
     ],
 
     'slugs' => [

--- a/Modules/HR/Tests/Feature/OpportunityStatusTest.php
+++ b/Modules/HR/Tests/Feature/OpportunityStatusTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Modules\HR\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\HR\Entities\Job;
+use Tests\TestCase;
+
+class OpportunityStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRolesAndPermissions();
+        $this->signIn('super-admin');
+    }
+
+    /**
+     * Assert that every value in opportunities-status has a corresponding
+     * key in opportunities-status-wp-mapping.
+     */
+    public function test_every_status_value_has_a_wp_mapping()
+    {
+        $statusValues = array_values(config('hr.opportunities-status'));
+        $wpMappingKeys = array_keys(config('hr.opportunities-status-wp-mapping'));
+
+        foreach ($statusValues as $dbValue) {
+            $this->assertContains(
+                $dbValue,
+                $wpMappingKeys,
+                "Database status value '{$dbValue}' is missing from opportunities-status-wp-mapping"
+            );
+        }
+    }
+
+    /**
+     * Assert that no two display labels map to the same database value
+     * in opportunities-status (i.e. no duplicate db values).
+     */
+    public function test_no_duplicate_status_db_values()
+    {
+        $statusValues = array_values(config('hr.opportunities-status'));
+        $uniqueValues = array_unique($statusValues);
+
+        $this->assertCount(
+            count($uniqueValues),
+            $statusValues,
+            'opportunities-status config contains duplicate database values'
+        );
+    }
+
+    /**
+     * Assert that the 'Closed' key maps to 'closed' (not 'draft').
+     */
+    public function test_closed_status_maps_to_closed_db_value()
+    {
+        $this->assertSame('closed', config('hr.opportunities-status')['Closed']);
+    }
+
+    /**
+     * Assert that 'closed' has a WP mapping entry.
+     */
+    public function test_closed_status_has_wp_mapping()
+    {
+        $this->assertArrayHasKey('closed', config('hr.opportunities-status-wp-mapping'));
+    }
+
+    /**
+     * Updating a job with status 'published' should persist that value.
+     */
+    public function test_status_published_persists_on_update()
+    {
+        $job = Job::factory()->create(['status' => 'draft', 'type' => 'job']);
+
+        $this->patch(
+            route('recruitment.opportunities.update', $job->id),
+            $this->validJobData(['status' => 'published'])
+        );
+
+        $this->assertDatabaseHas('hr_jobs', [
+            'id' => $job->id,
+            'status' => 'published',
+        ]);
+    }
+
+    /**
+     * Updating a job with status 'draft' should persist that value.
+     */
+    public function test_status_draft_persists_on_update()
+    {
+        $job = Job::factory()->create(['status' => 'published', 'type' => 'job']);
+
+        $this->patch(
+            route('recruitment.opportunities.update', $job->id),
+            $this->validJobData(['status' => 'draft'])
+        );
+
+        $this->assertDatabaseHas('hr_jobs', [
+            'id' => $job->id,
+            'status' => 'draft',
+        ]);
+    }
+
+    /**
+     * Updating a job with status 'closed' should persist 'closed', not 'draft'.
+     */
+    public function test_closed_status_persists_on_update_not_draft()
+    {
+        $job = Job::factory()->create(['status' => 'published', 'type' => 'job']);
+
+        $this->patch(
+            route('recruitment.opportunities.update', $job->id),
+            $this->validJobData(['status' => 'closed'])
+        );
+
+        $this->assertDatabaseHas('hr_jobs', [
+            'id' => $job->id,
+            'status' => 'closed',
+        ]);
+
+        $this->assertDatabaseMissing('hr_jobs', [
+            'id' => $job->id,
+            'status' => 'draft',
+        ]);
+    }
+
+    /**
+     * Updating a job with status 'pending-review' should persist that value.
+     */
+    public function test_status_pending_review_persists_on_update()
+    {
+        $job = Job::factory()->create(['status' => 'draft', 'type' => 'job']);
+
+        $this->patch(
+            route('recruitment.opportunities.update', $job->id),
+            $this->validJobData(['status' => 'pending-review'])
+        );
+
+        $this->assertDatabaseHas('hr_jobs', [
+            'id' => $job->id,
+            'status' => 'pending-review',
+        ]);
+    }
+
+    /**
+     * The edit form should render with the saved status marked as selected.
+     */
+    public function test_edit_form_shows_saved_status_as_selected()
+    {
+        $job = Job::factory()->create(['status' => 'published', 'type' => 'job']);
+
+        $response = $this->get(route('recruitment.opportunities.edit', $job->id));
+
+        $response->assertStatus(200);
+        $response->assertSee('value="published" selected', false);
+    }
+
+    /**
+     * The edit form for a job with status 'closed' should show 'closed' selected.
+     */
+    public function test_edit_form_shows_closed_status_as_selected()
+    {
+        $job = Job::factory()->create(['status' => 'closed', 'type' => 'job']);
+
+        $response = $this->get(route('recruitment.opportunities.edit', $job->id));
+
+        $response->assertStatus(200);
+        $response->assertSee('value="closed" selected', false);
+    }
+
+    /**
+     * Helper: returns a valid job data array for PATCH requests.
+     */
+    private function validJobData(array $overrides = []): array
+    {
+        return array_merge([
+            'title' => 'Software Engineer',
+            'domain' => 'engineering',
+            'description' => 'A test job description.',
+            'type' => 'job',
+            'status' => 'draft',
+        ], $overrides);
+    }
+}

--- a/resources/views/hr/job/create.blade.php
+++ b/resources/views/hr/job/create.blade.php
@@ -66,7 +66,7 @@
                         <label for="title" class="fz-14 leading-none text-secondary mb-1">Status</label>
                         <select class="form-control" name="status" id="status" value="{{ old('status') }}">
                             @foreach (config('hr.opportunities-status') as $status => $label)
-                                <option value="{{ $label }}" {{ old('status') == $status ? 'selected' : '' }}>{{ $status }}</option>
+                                <option value="{{ $label }}" {{ old('status') == $label ? 'selected' : '' }}>{{ $status }}</option>
                             @endforeach
                         </select>
                     </div>

--- a/resources/views/hr/job/edit.blade.php
+++ b/resources/views/hr/job/edit.blade.php
@@ -38,7 +38,7 @@
                         <label for="title" class="fz-14 leading-none text-secondary mb-1">Status</label>
                         <select class="form-control" name="status" id="status" value="{{ old('status') }}">
                             @foreach (config('hr.opportunities-status') as $status => $label)
-                                <option value="{{ $label }}" {{ old('status', $job->status) == $status ? 'selected' : '' }}>{{ $status }}</option>
+                                <option value="{{ $label }}" {{ old('status', $job->status) == $label ? 'selected' : '' }}>{{ $status }}</option>
                             @endforeach
                         </select>
                     </div>


### PR DESCRIPTION
Targets #3814

## Description of the changes

This PR fixes two distinct bugs that caused the opportunity status dropdown to always display "Draft" regardless of the saved value, and silently saved "Closed" opportunities as "draft" in the database.

**Bug 1 — Config typo:** `'Closed' => 'draft'` in `opportunities-status` config was corrected to `'Closed' => 'closed'`. This caused any opportunity saved with "Closed" to be stored as `'draft'` in the database.

**Bug 2 — Blade comparison (edit form):** The `@foreach` loop iterates `config('hr.opportunities-status')` as `$status` (display label) => `$label` (db value). The `selected` comparison was incorrectly comparing the saved db value against `$status` (the display label) instead of `$label` (the db value), so the dropdown never showed the current saved status.

**Bug 3 — Blade comparison (create form):** Same issue as Bug 2, affecting the create form's `old()` restoration after validation failure.

**Bug 4 — Missing WP mapping:** Added `'closed' => 'draft'` to `opportunities-status-wp-mapping` to prevent a runtime undefined index error in `JobObserver` when a job is saved with status `'closed'`.

## Breakdown & Estimates

- **T1** (~0.5h): Fix `'Closed' => 'closed'` in config and add `'closed'` WP mapping
- **T2** (~0.5h): Fix edit form Blade comparison (`$status` → `$label`)
- **T3** (~0.5h): Fix create form Blade comparison (`$status` → `$label`)
- **T4** (~2h): Write feature tests for config integrity, status persistence, and form rendering

**Expected Time Range:** 3.5 hours

## Checklist:
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)