### PR TITLE
#3813 Filter and sort job filter dropdown to show only published jobs

### DIFF
--- a/Modules/HR/Entities/Job.php
+++ b/Modules/HR/Entities/Job.php
@@ -119,4 +119,14 @@ class Job extends Model
             'internship',
         ]);
     }
+
+    public function scopePublished($query)
+    {
+        return $query->where('status', 'published');
+    }
+
+    public function scopeOrderByTitle($query, $direction = 'asc')
+    {
+        return $query->orderBy('title', $direction);
+    }
 }

--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -135,7 +135,7 @@ abstract class ApplicationController extends Controller
                 ->count();
         }
 
-        $attr['jobs'] = Job::all();
+        $attr['jobs'] = Job::published()->orderByTitle()->get();
         $attr['universities'] = University::all();
         $attr['tags'] = Tag::orderBy('name')->get();
         $attr['rounds'] = $hrRoundsCounts;

--- a/Modules/HR/Services/ApplicationService.php
+++ b/Modules/HR/Services/ApplicationService.php
@@ -73,7 +73,7 @@ class ApplicationService implements ApplicationServiceContract
                 ->count();
         }
 
-        $attr['jobs'] = Job::all();
+        $attr['jobs'] = Job::published()->orderByTitle()->get();
         $attr['tags'] = Tag::orderBy('name')->get();
 
         if (Module::has('User')) {

--- a/Modules/HR/Tests/Feature/JobFilterTest.php
+++ b/Modules/HR/Tests/Feature/JobFilterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Modules\HR\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\HR\Entities\Job;
+use Tests\TestCase;
+
+class JobFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRolesAndPermissions();
+        $this->signIn('super-admin');
+    }
+
+    public function test_published_jobs_appear_in_filter_dropdown()
+    {
+        $job = Job::factory()->create(['status' => 'published', 'title' => 'Published Developer']);
+
+        $response = $this->get(route('applications.job.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee($job->title);
+    }
+
+    public function test_closed_jobs_are_excluded_from_filter_dropdown()
+    {
+        $job = Job::factory()->create(['status' => 'closed', 'title' => 'Closed Engineer Role']);
+
+        $response = $this->get(route('applications.job.index'));
+
+        $response->assertStatus(200);
+        $response->assertDontSee($job->title);
+    }
+
+    public function test_draft_jobs_are_excluded_from_filter_dropdown()
+    {
+        $job = Job::factory()->create(['status' => 'draft', 'title' => 'Draft Intern Position']);
+
+        $response = $this->get(route('applications.job.index'));
+
+        $response->assertStatus(200);
+        $response->assertDontSee($job->title);
+    }
+
+    public function test_published_jobs_are_sorted_alphabetically_in_filter_dropdown()
+    {
+        Job::factory()->create(['status' => 'published', 'title' => 'Zebra Engineer']);
+        Job::factory()->create(['status' => 'published', 'title' => 'Alpha Developer']);
+        Job::factory()->create(['status' => 'published', 'title' => 'Mid Designer']);
+
+        $response = $this->get(route('applications.job.index'));
+
+        $response->assertStatus(200);
+
+        $content = $response->getContent();
+        $alphaPos = strpos($content, 'Alpha Developer');
+        $midPos = strpos($content, 'Mid Designer');
+        $zebraPos = strpos($content, 'Zebra Engineer');
+
+        $this->assertLessThan($midPos, $alphaPos, 'Alpha Developer should appear before Mid Designer');
+        $this->assertLessThan($zebraPos, $midPos, 'Mid Designer should appear before Zebra Engineer');
+    }
+
+    public function test_scope_published_returns_only_published_jobs()
+    {
+        Job::factory()->create(['status' => 'published']);
+        Job::factory()->create(['status' => 'published']);
+        Job::factory()->create(['status' => 'closed']);
+        Job::factory()->create(['status' => 'draft']);
+
+        $publishedJobs = Job::published()->get();
+
+        $this->assertCount(2, $publishedJobs);
+        $publishedJobs->each(function ($job) {
+            $this->assertEquals('published', $job->status);
+        });
+    }
+
+    public function test_scope_order_by_title_returns_jobs_sorted_alphabetically()
+    {
+        Job::factory()->create(['status' => 'published', 'title' => 'Zebra Role']);
+        Job::factory()->create(['status' => 'published', 'title' => 'Alpha Role']);
+        Job::factory()->create(['status' => 'published', 'title' => 'Mid Role']);
+
+        $jobs = Job::published()->orderByTitle()->get();
+
+        $this->assertEquals('Alpha Role', $jobs->first()->title);
+        $this->assertEquals('Zebra Role', $jobs->last()->title);
+    }
+}


### PR DESCRIPTION
Targets #3813

## Description of the changes
- Added `scopePublished()` and `scopeOrderByTitle()` query scopes to the `Job` model so the filter logic is centralized and reusable across the codebase.
- Updated `ApplicationController::index()` and `ApplicationService::index()` to replace `Job::all()` with `Job::published()->orderByTitle()->get()`, so the job filter dropdown on the recruitment pages only shows published jobs sorted alphabetically.
- Added feature tests covering published/closed/draft visibility, alphabetical sort order, and unit-level scope behaviour.

## Breakdown & Estimates
- T1: Add `scopePublished` and `scopeOrderByTitle` to `Job` model (~0.5h)
- T2: Update `ApplicationController` to use new scopes (~0.5h)
- T3: Update `ApplicationService` to use new scopes (~0.5h)
- T4: Write feature tests in `JobFilterTest` (~2h)
- T5: Verify `HrJobsFactory` supports status overrides — no changes needed (~0.5h)

**Expected Time Range:** ~4 hours

## Checklist:
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job listings now display only published positions, filtering out draft and closed jobs.
  * Published jobs are automatically sorted alphabetically by title for improved organization.

* **Tests**
  * Added comprehensive tests to verify job filtering and sorting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->