### PR TITLE
#3816 Copy candidate details for AI evaluation

### DIFF
--- a/resources/views/hr/application/copy-for-ai-evaluation.blade.php
+++ b/resources/views/hr/application/copy-for-ai-evaluation.blade.php
@@ -1,0 +1,25 @@
+@php
+    $clipboardLines = [];
+    $clipboardLines[] = 'Candidate to evaluate:';
+    $clipboardLines[] = $applicant->name . ', applied on ' . $application->created_at->format(config('constants.display_date_format'));
+
+    if (isset($applicationFormDetails->value)) {
+        $formFields = json_decode($applicationFormDetails->value);
+        if ($formFields) {
+            foreach ($formFields as $label => $value) {
+                if (!empty($value)) {
+                    $clipboardLines[] = $label;
+                    $clipboardLines[] = $value;
+                }
+            }
+        }
+    }
+
+    $clipboardText = implode("\n", $clipboardLines);
+@endphp
+<span class="c-pointer btn-clipboard btn btn-outline-secondary btn-sm"
+    data-clipboard-text="{{ $clipboardText }}"
+    data-toggle="tooltip"
+    title="Click to copy candidate details for AI evaluation">
+    <i class="fa fa-clone mr-1"></i>Copy for AI evaluation
+</span>

--- a/resources/views/hr/application/details.blade.php
+++ b/resources/views/hr/application/details.blade.php
@@ -31,6 +31,7 @@
                             @endif
                             <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#customApplicationMail">Send mail</button>
                             @include('hr.custom-application-mail-modal', ['application' => $application])
+                            @include('hr.application.copy-for-ai-evaluation')
                         </div>
                         <div class="text-right fz-14">
                             <span class="c-pointer btn-clipboard text-right" data-clipboard-text="{{ $application->getScheduleInterviewLink() }}" data-toggle="tooltip" title="Click to copy">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -459,6 +459,7 @@
                                                                         {{ config("constants.hr.status.$application->status.title") }}
                                                                     </div>
                                                                 @endif
+                                                                @include('hr.application.copy-for-ai-evaluation')
                                                             </div>
                                                         </div>
                                                         <div class="card-body">
@@ -967,6 +968,7 @@
                                                                         {{ config("constants.hr.status.$application->status.title") }}
                                                                     </div>
                                                                 @endif
+                                                                @include('hr.application.copy-for-ai-evaluation')
                                                             </div>
                                                         </div>
                                                         <div class="card-body">


### PR DESCRIPTION
Targets #3816

## Description of the changes
Adds a "Copy for AI evaluation" button to the Applicant Details page and both Resume Screening sections of the Evaluate page. Clicking the button copies a pre-formatted text snippet (candidate name, applied-on date, and all non-empty form fields) to the clipboard in one click. The button reuses the existing ClipboardJS global setup (`btn-clipboard` class) and the existing tooltip feedback handler (`Copied!`), so no new JavaScript or libraries are needed. Text is assembled server-side in a shared Blade partial to avoid duplicating the logic across three insertion points.

## Breakdown & Estimates
- T1 (~1.5h): Create `copy-for-ai-evaluation.blade.php` partial — assembles clipboard text, renders `btn-clipboard` span with `data-clipboard-text`
- T2 (~1h): Include partial in `details.blade.php` card header action area
- T3 (~1.5h): Include partial in both "Applicant Details" card header sections in `edit.blade.php` (pre-trial and regular rounds)
- T4 (~1.5h): Manual testing across all scenarios (no code changes)

**Expected Time Range:** ~5.5 hours

## Checklist:
- [x] The PR title follows this syntax: <#IssueID> \<PR Title>
- [x] I have linked the issue id in the PR description.
- [x] I have performed a self-review of my own code.
- [x] I have added comments on my code changes where required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)