### PR TITLE
fix: contract history link points to correct contract on project show

### DIFF
--- a/Modules/Project/Resources/views/show.blade.php
+++ b/Modules/Project/Resources/views/show.blade.php
@@ -320,7 +320,7 @@
             <tbody>
                 @foreach ($project->projectContracts as $contract)
                     <tr>
-                        <td> <a href="{{ route('pdf.show', $contract->first()) }}"
+                        <td> <a href="{{ route('pdf.show', $contract) }}"
                                 target="_blank">{{ basename($contract->contract_file_path) }}</a></td>
                         <td>{{ optional($project->start_date)->format('d M Y') ?? '-' }}</td>
                         <td>{{ optional($project->end_date)->format('d M Y') ?? '-' }}</td>


### PR DESCRIPTION
## Summary
- On `/projects/{id}/show` the **Contract History** table rendered the same href on every row, always opening the first `project_contracts` row in the database.
- Root cause: inside `@foreach ($project->projectContracts as $contract)`, the link used `$contract->first()`. `first()` is not a Model instance method — Eloquent's `__call` forwards it to the query builder, returning the first row of the table globally.
- Fix: pass `$contract` directly to `route('pdf.show', ...)` so implicit route-model binding resolves to the correct record per row.

## Test plan
- [ ] Visit `/projects/{id}/show` for a project with multiple contracts.
- [ ] Expand **Contract History**.
- [ ] Click each row's filename — each should open its own PDF, not the first contract.
- [ ] Verify projects with a single contract still work.
- [ ] Verify the top "Contract File" link (unchanged, points to latest contract via `projectContracts->first()` on the Collection) still opens correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Contract History PDF file link to properly resolve and display the correct contract document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->