### PR TITLE
Restore Copy for AI evaluation feature

### DIFF
--- a/resources/views/hr/application/copy-for-ai-evaluation.blade.php
+++ b/resources/views/hr/application/copy-for-ai-evaluation.blade.php
@@ -1,0 +1,25 @@
+@php
+    $clipboardLines = [];
+    $clipboardLines[] = 'Candidate to evaluate:';
+    $clipboardLines[] = $applicant->name . ', applied on ' . $application->created_at->format(config('constants.display_date_format'));
+
+    if (isset($applicationFormDetails->value)) {
+        $formFields = json_decode($applicationFormDetails->value);
+        if ($formFields) {
+            foreach ($formFields as $label => $value) {
+                if (!empty($value)) {
+                    $clipboardLines[] = $label;
+                    $clipboardLines[] = $value;
+                }
+            }
+        }
+    }
+
+    $clipboardText = implode("\n", $clipboardLines);
+@endphp
+<span class="c-pointer btn-clipboard btn btn-outline-secondary btn-sm"
+    data-clipboard-text="{{ $clipboardText }}"
+    data-toggle="tooltip"
+    title="Click to copy candidate details for AI evaluation">
+    <i class="fa fa-clone mr-1"></i>Copy for AI evaluation
+</span>

--- a/resources/views/hr/application/details.blade.php
+++ b/resources/views/hr/application/details.blade.php
@@ -31,6 +31,7 @@
                             @endif
                             <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#customApplicationMail">Send mail</button>
                             @include('hr.custom-application-mail-modal', ['application' => $application])
+                            @include('hr.application.copy-for-ai-evaluation')
                         </div>
                         <div class="text-right fz-14">
                             <span class="c-pointer btn-clipboard text-right" data-clipboard-text="{{ $application->getScheduleInterviewLink() }}" data-toggle="tooltip" title="Click to copy">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -459,6 +459,7 @@
                                                                         {{ config("constants.hr.status.$application->status.title") }}
                                                                     </div>
                                                                 @endif
+                                                                @include('hr.application.copy-for-ai-evaluation')
                                                             </div>
                                                         </div>
                                                         <div class="card-body">
@@ -967,6 +968,7 @@
                                                                         {{ config("constants.hr.status.$application->status.title") }}
                                                                     </div>
                                                                 @endif
+                                                                @include('hr.application.copy-for-ai-evaluation')
                                                             </div>
                                                         </div>
                                                         <div class="card-body">


### PR DESCRIPTION
## Summary
- Restores the **Copy for AI evaluation** button removed in #3824.
- Re-adds `resources/views/hr/application/copy-for-ai-evaluation.blade.php` partial.
- Re-adds three `@include('hr.application.copy-for-ai-evaluation')` references in `details.blade.php` and `edit.blade.php` (both Applicant Details card headers).

## Test plan
- [ ] Visit Applicant Details page — "Copy for AI evaluation" button renders.
- [ ] Visit Evaluate page (pre-trial round) — button renders in Applicant Details card header.
- [ ] Visit Evaluate page (regular round) — button renders in Applicant Details card header.
- [ ] Click button — clipboard text copies candidate name, applied date, and form field labels/values.
- [ ] No Blade view-not-found errors in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)