### PR TITLE
fix(hr): tighten Copy-for-AI button and align Resume Screening header

### DIFF
--- a/resources/views/hr/application/copy-for-ai-evaluation.blade.php
+++ b/resources/views/hr/application/copy-for-ai-evaluation.blade.php
@@ -8,7 +8,7 @@
         if ($formFields) {
             foreach ($formFields as $label => $value) {
                 if (!empty($value)) {
-                    $clipboardLines[] = $label;
+                    $clipboardLines[] = str_ireplace('eligbility', 'eligibility', $label);
                     $clipboardLines[] = $value;
                 }
             }
@@ -20,6 +20,6 @@
 <span class="c-pointer btn-clipboard btn btn-outline-secondary btn-sm"
     data-clipboard-text="{{ $clipboardText }}"
     data-toggle="tooltip"
-    title="Click to copy candidate details for AI evaluation">
-    <i class="fa fa-clone mr-1"></i>Copy for AI evaluation
+    title="Copy candidate details for AI evaluation">
+    <i class="fa fa-clone"></i>
 </span>

--- a/resources/views/hr/application/copy-for-ai-evaluation.blade.php
+++ b/resources/views/hr/application/copy-for-ai-evaluation.blade.php
@@ -8,7 +8,7 @@
         if ($formFields) {
             foreach ($formFields as $label => $value) {
                 if (!empty($value)) {
-                    $clipboardLines[] = str_ireplace('eligbility', 'eligibility', $label);
+                    $clipboardLines[] = $label;
                     $clipboardLines[] = $value;
                 }
             }

--- a/resources/views/hr/application/details.blade.php
+++ b/resources/views/hr/application/details.blade.php
@@ -110,7 +110,7 @@
                     @if (isset($applicationFormDetails->value))
                         @foreach(json_decode($applicationFormDetails->value) as $field => $value)
                             <div class="form-group col-md-12">
-                                <label class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
+                                <label class="text-secondary fz-14 leading-none mb-0.16">{{ str_ireplace('eligbility', 'eligibility', $field) }}</label>
                                 <div>{{ $value }}</div>
                             </div>
                         @endforeach

--- a/resources/views/hr/application/details.blade.php
+++ b/resources/views/hr/application/details.blade.php
@@ -110,7 +110,7 @@
                     @if (isset($applicationFormDetails->value))
                         @foreach(json_decode($applicationFormDetails->value) as $field => $value)
                             <div class="form-group col-md-12">
-                                <label class="text-secondary fz-14 leading-none mb-0.16">{{ str_ireplace('eligbility', 'eligibility', $field) }}</label>
+                                <label class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
                                 <div>{{ $value }}</div>
                             </div>
                         @endforeach

--- a/resources/views/hr/application/details.blade.php
+++ b/resources/views/hr/application/details.blade.php
@@ -9,9 +9,9 @@
             <div class="card-header">
                 <div class="row">
                     <div class="col-6">
-                        <div>Applicant Details</div>
+                        <div class="mb-2">Applicant Details</div>
                         @foreach ($application->tags as $tag)
-                            <div class="badge text-uppercase fz-xl-12 c-pointer" style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color  }};" data-toggle="tooltip" data-placement="top" title="{{ $tag->description }}">
+                            <div class="badge text-uppercase fz-xl-12 c-pointer mr-1 mb-1" style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color  }};" data-toggle="tooltip" data-placement="top" title="{{ $tag->description }}">
                                 @if ($tag->icon)
                                     {!! config("tags.icons.{$tag->icon}") !!}
                                 @endif
@@ -19,17 +19,17 @@
                             </div>
                         @endforeach
                         @if (!in_array($application->status, ['in-progress', 'new']))
-                            <div class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
+                            <div class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12 mr-1 mb-1">
                                 {{ config("constants.hr.status.$application->status.title") }}
                             </div>
                         @endif
                     </div>
                     <div class="col-6 text-right">
-                        <div class="mb-1">
+                        <div class="mb-1 d-flex justify-content-end align-items-center flex-wrap">
                             @if($application->latestApplicationRound->hr_round_id == 1)
-                                <a href="{{ route('applications.job.edit', $application->id) }}" class="btn btn-primary btn-sm" target="_self">Evaluate</a>
+                                <a href="{{ route('applications.job.edit', $application->id) }}" class="btn btn-primary btn-sm mr-2" target="_self">Evaluate</a>
                             @endif
-                            <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#customApplicationMail">Send mail</button>
+                            <button type="button" class="btn btn-primary btn-sm mr-2" data-toggle="modal" data-target="#customApplicationMail">Send mail</button>
                             @include('hr.custom-application-mail-modal', ['application' => $application])
                             @include('hr.application.copy-for-ai-evaluation')
                         </div>

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -440,25 +440,27 @@
                                                 @if ($applicationRound->round->name == 'Resume Screening')
                                                     <div class="card-body border-0">
                                                         <div class="card-header border-0">
-                                                            <div class="d-flex justify-content-between">
-                                                                <div>Applicant Details</div>
-                                                                @foreach ($application->tags as $tag)
-                                                                    <div class="badge text-uppercase fz-xl-12 c-pointer"
-                                                                        style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color }};"
-                                                                        data-toggle="tooltip" data-placement="top"
-                                                                        title="{{ $tag->description }}">
-                                                                        @if ($tag->icon)
-                                                                            {!! config("tags.icons.{$tag->icon}") !!}
-                                                                        @endif
-                                                                        {{ $tag->name }}
-                                                                    </div>
-                                                                @endforeach
-                                                                @if (!in_array($application->status, ['in-progress', 'new']))
-                                                                    <div
-                                                                        class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
-                                                                        {{ config("constants.hr.status.$application->status.title") }}
-                                                                    </div>
-                                                                @endif
+                                                            <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                                                <div class="d-flex align-items-center flex-wrap">
+                                                                    <div class="mr-2">Applicant Details</div>
+                                                                    @foreach ($application->tags as $tag)
+                                                                        <div class="badge text-uppercase fz-xl-12 c-pointer mr-2 align-self-center"
+                                                                            style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color }};"
+                                                                            data-toggle="tooltip" data-placement="top"
+                                                                            title="{{ $tag->description }}">
+                                                                            @if ($tag->icon)
+                                                                                {!! config("tags.icons.{$tag->icon}") !!}
+                                                                            @endif
+                                                                            {{ $tag->name }}
+                                                                        </div>
+                                                                    @endforeach
+                                                                    @if (!in_array($application->status, ['in-progress', 'new']))
+                                                                        <div
+                                                                            class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12 mr-2 align-self-center">
+                                                                            {{ config("constants.hr.status.$application->status.title") }}
+                                                                        </div>
+                                                                    @endif
+                                                                </div>
                                                                 @include('hr.application.copy-for-ai-evaluation')
                                                             </div>
                                                         </div>
@@ -949,25 +951,27 @@
                                                 @if ($applicationRound->round->name == 'Resume Screening')
                                                     <div class="card mb-2 border-0">
                                                         <div class="card-header border-0">
-                                                            <div class="d-flex justify-content-between">
-                                                                <div>Applicant Details</div>
-                                                                @foreach ($application->tags as $tag)
-                                                                    <div class="badge text-uppercase fz-xl-12 c-pointer"
-                                                                        style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color }};"
-                                                                        data-toggle="tooltip" data-placement="top"
-                                                                        title="{{ $tag->description }}">
-                                                                        @if ($tag->icon)
-                                                                            {!! config("tags.icons.{$tag->icon}") !!}
-                                                                        @endif
-                                                                        {{ $tag->name }}
-                                                                    </div>
-                                                                @endforeach
-                                                                @if (!in_array($application->status, ['in-progress', 'new']))
-                                                                    <div
-                                                                        class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12">
-                                                                        {{ config("constants.hr.status.$application->status.title") }}
-                                                                    </div>
-                                                                @endif
+                                                            <div class="d-flex justify-content-between align-items-center flex-wrap">
+                                                                <div class="d-flex align-items-center flex-wrap">
+                                                                    <div class="mr-2">Applicant Details</div>
+                                                                    @foreach ($application->tags as $tag)
+                                                                        <div class="badge text-uppercase fz-xl-12 c-pointer mr-2 align-self-center"
+                                                                            style="background-color: {{ $tag->background_color }};color: {{ $tag->text_color }};"
+                                                                            data-toggle="tooltip" data-placement="top"
+                                                                            title="{{ $tag->description }}">
+                                                                            @if ($tag->icon)
+                                                                                {!! config("tags.icons.{$tag->icon}") !!}
+                                                                            @endif
+                                                                            {{ $tag->name }}
+                                                                        </div>
+                                                                    @endforeach
+                                                                    @if (!in_array($application->status, ['in-progress', 'new']))
+                                                                        <div
+                                                                            class="{{ config("constants.hr.status.$application->status.class") }} text-uppercase card-status-highlight fz-12 mr-2 align-self-center">
+                                                                            {{ config("constants.hr.status.$application->status.title") }}
+                                                                        </div>
+                                                                    @endif
+                                                                </div>
                                                                 @include('hr.application.copy-for-ai-evaluation')
                                                             </div>
                                                         </div>

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -604,7 +604,7 @@
                                                                     @foreach (json_decode($applicationFormDetails->value) as $field => $value)
                                                                         <div class="form-group col-md-12">
                                                                             <label
-                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
+                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ str_ireplace('eligbility', 'eligibility', $field) }}</label>
                                                                             <div>{{ $value }}</div>
                                                                             @if (!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
                                                                                 <div class="mt-2 evaluation-score">
@@ -1126,7 +1126,7 @@
                                                                     @foreach (json_decode($applicationFormDetails->value) ?? [] as $field => $value)
                                                                         <div class="form-group col-md-12">
                                                                             <label
-                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
+                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ str_ireplace('eligbility', 'eligibility', $field) }}</label>
                                                                             <div>{{ $value }}</div>
                                                                             @if (!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
                                                                                 <div class="mt-2 evaluation-score">

--- a/resources/views/hr/application/edit.blade.php
+++ b/resources/views/hr/application/edit.blade.php
@@ -604,7 +604,7 @@
                                                                     @foreach (json_decode($applicationFormDetails->value) as $field => $value)
                                                                         <div class="form-group col-md-12">
                                                                             <label
-                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ str_ireplace('eligbility', 'eligibility', $field) }}</label>
+                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
                                                                             <div>{{ $value }}</div>
                                                                             @if (!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
                                                                                 <div class="mt-2 evaluation-score">
@@ -1126,7 +1126,7 @@
                                                                     @foreach (json_decode($applicationFormDetails->value) ?? [] as $field => $value)
                                                                         <div class="form-group col-md-12">
                                                                             <label
-                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ str_ireplace('eligbility', 'eligibility', $field) }}</label>
+                                                                                class="text-secondary fz-14 leading-none mb-0.16">{{ $field }}</label>
                                                                             <div>{{ $value }}</div>
                                                                             @if (!$application->marks && $application->latestApplicationRound->hr_round_id == 1)
                                                                                 <div class="mt-2 evaluation-score">


### PR DESCRIPTION
## Summary
1. **Applicant Details card** (`details.blade.php`): the **Copy for AI evaluation** control is now an icon-only span with a tooltip, so it no longer wraps onto a second row below `Evaluate` / `Send mail`.
2. **Resume Screening card** (`edit.blade.php`, both header blocks): the header used `d-flex justify-content-between` with the title, every tag, the status pill, and the Copy-for-AI button as direct flex children, so `justify-content-between` spread them across the full width — tags and the status pill drifted away from the title and inherited inconsistent vertical alignment. Wrapped the title + tags + status pill in an inner `d-flex align-items-center flex-wrap` container with `mr-2` spacing per item, and left the Copy-for-AI include as the second outer flex child so it is anchored on the right. Added `align-items-center` + `flex-wrap` on the outer row so badges stay vertically centered with the title and wrap gracefully on narrow viewports.

Files touched:
- `resources/views/hr/application/copy-for-ai-evaluation.blade.php` — icon-only button + tooltip text.
- `resources/views/hr/application/edit.blade.php` — both Resume Screening header blocks restructured into nested flex.

## Out of scope
The "Reason for eligbility" misspelling is **data**, not source. It lives in `hr_application_meta.value` (JSON, `key='form-data'`) and is written by the external careers/hire website that POSTs to `/api/applicants`. Fix path:
1. Correct the field key in the external website form/template.
2. One-time DB cleanup on `hr_application_meta` to fix already-stored rows.

A display-side `str_ireplace` workaround was deliberately reverted in this PR.

## Test plan
- [ ] Open `/hr/recruitment/applicant/details/show/{id}` — **Copy for AI evaluation** is now a small icon next to `Evaluate` / `Send mail`, no wrap, no displaced badges.
- [ ] Hover the icon — tooltip "Copy candidate details for AI evaluation" appears.
- [ ] Click the icon, paste somewhere — clipboard payload still contains candidate name, applied date, and form_data fields.
- [ ] Open the Resume Screening view in `edit.blade.php` (both new and historical card variants) — `Applicant Details` title, tags (e.g. `NEW APPLICATION`), and the status pill sit on one line, vertically centered, with consistent spacing; the Copy-for-AI icon sits at the far right of the same row.
- [ ] Resize the window narrow — the inner group wraps to a second line gracefully without breaking the right-anchored Copy-for-AI icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)