### PR TITLE
chore(hr): disable applicant auto-responder email

### DIFF
--- a/Modules/HR/Providers/EventServiceProvider.php
+++ b/Modules/HR/Providers/EventServiceProvider.php
@@ -43,7 +43,7 @@ class EventServiceProvider extends ServiceProvider
         ],
 
         ApplicantEmailVerified::class => [
-            AutoRespondApplicant::class,
+            // AutoRespondApplicant::class,
         ],
 
         JobUpdated::class => [


### PR DESCRIPTION
## Summary
- Disables the auto-responder email that fires after a candidate verifies their email on application
- Removes `AutoRespondApplicant` from the `ApplicantEmailVerified` listener mapping (commented out for easy revert)
- Settings template ("Auto responder mail to applicant" in HR Settings) is left untouched

## Why
Stopping the outbound email to applicants without ripping out the template/mailable, so it can be re-enabled by un-commenting a single line.

## Test plan
- [ ] Verify a new application + email verification does not trigger an outbound auto-responder mail
- [ ] Confirm the HR Settings → "Auto responder mail to applicant" panel still renders and saves
- [ ] Confirm no other listeners on `ApplicantEmailVerified` are impacted (it's the only one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)