### PR TITLE
feat(hr): include Graduation Year in Copy for AI evaluation

### DIFF
--- a/resources/views/hr/application/copy-for-ai-evaluation.blade.php
+++ b/resources/views/hr/application/copy-for-ai-evaluation.blade.php
@@ -3,6 +3,10 @@
     $clipboardLines[] = 'Candidate to evaluate:';
     $clipboardLines[] = $applicant->name . ', applied on ' . $application->created_at->format(config('constants.display_date_format'));
 
+    if (!empty($applicant->graduation_year)) {
+        $clipboardLines[] = 'Graduation Year: ' . $applicant->graduation_year;
+    }
+
     if (isset($applicationFormDetails->value)) {
         $formFields = json_decode($applicationFormDetails->value);
         if ($formFields) {


### PR DESCRIPTION
## Summary
- Adds the applicant's graduation year to the clipboard text produced by the **Copy for AI evaluation** button on the Applicant Details page.
- The new line sits between the applied-on line and the application form fields, and is skipped when `graduation_year` is empty.

## Resulting clipboard format
```
Candidate to evaluate:
Vivek Tanwar, applied on 06/04/2026
Graduation Year: 2024
Reason for eligibility
Because I have a problem solving mindset and can....
```

## Test plan
- [ ] Open an Applicant Details page for a candidate with a graduation year set, click the Copy for AI evaluation button, paste into a text field, and confirm the `Graduation Year: <year>` line appears between the applied-on line and the first form field.
- [ ] Repeat for an applicant without a graduation year and confirm the line is omitted (no extra blank line).
- [ ] Verify the button still works in all three include sites (`details.blade.php` and both occurrences in `edit.blade.php`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)