### PR TITLE
fix(hr): sort universities alphabetically in recruitment filter dropdown

### DIFF
--- a/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
+++ b/Modules/HR/Http/Controllers/Recruitment/ApplicationController.php
@@ -136,7 +136,7 @@ abstract class ApplicationController extends Controller
         }
 
         $attr['jobs'] = Job::published()->orderByTitle()->get();
-        $attr['universities'] = University::all();
+        $attr['universities'] = University::orderBy('name')->get();
         $attr['tags'] = Tag::orderBy('name')->get();
         $attr['rounds'] = $hrRoundsCounts;
         $attr['roundFilters'] = Round::orderBy('name')->get();


### PR DESCRIPTION
## Summary
- The university dropdown filter on `/hr/recruitment/job` and `/hr/recruitment/internship` rendered entries in insertion order, making it hard to locate a specific university.
- Updated [`ApplicationController::index()`](Modules/HR/Http/Controllers/Recruitment/ApplicationController.php#L139) to order by `name`, matching the same controller's `edit()` method (line 237) and the other filter dropdowns on the page (`Tag`, `Round`, `User`, `Job`, all already ordered).
- Single-line change; no schema, route, view, or behavioral change beyond ordering.

## Affected pages
- `/hr/recruitment/job` (`JobApplicationController`)
- `/hr/recruitment/internship` (`InternshipApplicationController`)

Both inherit `index()` from `ApplicationController`. `VolunteerApplicationController` overrides `index()` and does not surface a university filter, so it is unaffected.

## Test plan
- [ ] Visit `/hr/recruitment/job` and confirm the **University** filter dropdown lists universities A→Z.
- [ ] Visit `/hr/recruitment/internship` and confirm the same.
- [ ] Select a university from the dropdown and verify the filter still applies correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)