### PR TITLE
feat(prospect): prospect_engagements table

### DIFF
--- a/Modules/Prospect/Database/Migrations/2026_05_30_000001_create_prospect_engagements_table.php
+++ b/Modules/Prospect/Database/Migrations/2026_05_30_000001_create_prospect_engagements_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProspectEngagementsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('prospect_engagements', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('prospect_id');
+            $table->unsignedBigInteger('project_id')->nullable();
+            $table->string('short_descriptor');
+            $table->integer('year');
+            $table->string('stage')->default('inquiry');
+            $table->integer('owner_user_id')->unsigned()->nullable();
+            $table->date('submission_due_date')->nullable();
+            $table->date('proposal_sent_date')->nullable();
+            $table->date('last_touch_date')->nullable();
+            $table->text('next_action')->nullable();
+            $table->boolean('drift_flag')->default(false);
+            $table->timestamp('closed_at')->nullable();
+            $table->string('close_reason')->nullable();
+            $table->string('notes_path')->nullable();
+            $table->timestamps();
+
+            $table->foreign('prospect_id')->references('id')->on('prospects')->onDelete('cascade');
+            $table->foreign('project_id')->references('id')->on('projects')->onDelete('set null');
+            $table->foreign('owner_user_id')->references('id')->on('users')->onDelete('set null');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('prospect_engagements');
+    }
+}

--- a/Modules/Prospect/Database/factories/ProspectEngagementFactory.php
+++ b/Modules/Prospect/Database/factories/ProspectEngagementFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+use Faker\Generator as Faker;
+use Modules\Prospect\Entities\Prospect;
+use Modules\Prospect\Entities\ProspectEngagement;
+use Modules\User\Entities\User;
+
+$factory->define(ProspectEngagement::class, function (Faker $faker) {
+    // FK dependencies: Prospect uses the module's legacy $factory->define
+    // convention (see ProspectFactory), while the User model uses the modern
+    // HasFactory trait and has no legacy factory — hence User::factory() here.
+    return [
+        'prospect_id' => function () {
+            return factory(Prospect::class)->create()->id;
+        },
+        'project_id' => null,
+        'short_descriptor' => $faker->slug(2),
+        'year' => 2026,
+        'stage' => 'inquiry',
+        'owner_user_id' => function () {
+            return User::factory()->create()->id;
+        },
+        'submission_due_date' => null,
+        'proposal_sent_date' => null,
+        'last_touch_date' => $faker->date(),
+        'next_action' => $faker->sentence(),
+        'drift_flag' => false,
+        'notes_path' => null,
+    ];
+});

--- a/Modules/Prospect/Database/factories/ProspectFactory.php
+++ b/Modules/Prospect/Database/factories/ProspectFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+use Faker\Generator as Faker;
+use Modules\Prospect\Entities\Prospect;
+use Modules\User\Entities\User;
+
+$factory->define(Prospect::class, function (Faker $faker) {
+    return [
+        'organization_name' => $faker->company,
+        'poc_user_id' => function () {
+            return User::factory()->create()->id;
+        },
+        'proposal_sent_date' => $faker->date(),
+        'domain' => $faker->word,
+        'customer_type' => 'prospect',
+        'budget' => $faker->numberBetween(100000, 5000000),
+        'proposal_status' => 'draft',
+        'rfp_link' => $faker->url,
+        'proposal_link' => $faker->url,
+        'currency' => 'INR',
+    ];
+});

--- a/Modules/Prospect/Entities/Prospect.php
+++ b/Modules/Prospect/Entities/Prospect.php
@@ -62,4 +62,9 @@ class Prospect extends Model
     {
         return $this->hasMany(ProspectInsight::class);
     }
+
+    public function engagements()
+    {
+        return $this->hasMany(ProspectEngagement::class);
+    }
 }

--- a/Modules/Prospect/Entities/ProspectEngagement.php
+++ b/Modules/Prospect/Entities/ProspectEngagement.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Modules\Prospect\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Modules\Project\Entities\Project;
+use Modules\User\Entities\User;
+
+class ProspectEngagement extends Model
+{
+    /**
+     * Allowed pre-sales stages. Transition validation is enforced downstream
+     * in the MCP write tools; this constant is the shared reference.
+     */
+    public const STAGES = [
+        'inquiry',
+        'qualified',
+        'proposal_drafting',
+        'proposal_submitted',
+        'negotiation',
+        'won',
+        'lost',
+        'dropped',
+    ];
+
+    protected $table = 'prospect_engagements';
+
+    /**
+     * Explicitly populated (sibling Prospect entities use an empty guard).
+     * This model is mass-assigned via Model::create() in tests and by the
+     * downstream MCP write tools; there is no global Model::unguard() in this
+     * app, so the fillable list must be explicit for those creates to persist.
+     */
+    protected $fillable = [
+        'prospect_id',
+        'project_id',
+        'short_descriptor',
+        'year',
+        'stage',
+        'owner_user_id',
+        'submission_due_date',
+        'proposal_sent_date',
+        'last_touch_date',
+        'next_action',
+        'drift_flag',
+        'closed_at',
+        'close_reason',
+        'notes_path',
+    ];
+
+    protected $casts = [
+        'year' => 'integer',
+        'drift_flag' => 'boolean',
+        'submission_due_date' => 'datetime:Y-m-d',
+        'proposal_sent_date' => 'datetime:Y-m-d',
+        'last_touch_date' => 'datetime:Y-m-d',
+        'closed_at' => 'datetime',
+    ];
+
+    public function prospect()
+    {
+        return $this->belongsTo(Prospect::class, 'prospect_id');
+    }
+
+    public function owner()
+    {
+        return $this->belongsTo(User::class, 'owner_user_id');
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class, 'project_id');
+    }
+}

--- a/Modules/Prospect/Tests/Feature/ProspectEngagementTest.php
+++ b/Modules/Prospect/Tests/Feature/ProspectEngagementTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Modules\Prospect\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Prospect\Entities\Prospect;
+use Modules\Prospect\Entities\ProspectEngagement;
+use Tests\TestCase;
+
+class ProspectEngagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_persists_a_prospect_engagement()
+    {
+        $engagement = factory(ProspectEngagement::class)->create([
+            'short_descriptor' => 'cotton-traceability',
+            'year' => 2026,
+        ]);
+
+        $this->assertDatabaseHas('prospect_engagements', [
+            'id' => $engagement->id,
+            'short_descriptor' => 'cotton-traceability',
+            'year' => 2026,
+        ]);
+    }
+
+    public function test_stage_defaults_to_inquiry()
+    {
+        $prospect = factory(Prospect::class)->create();
+
+        $engagement = ProspectEngagement::create([
+            'prospect_id' => $prospect->id,
+            'short_descriptor' => 'website-cms',
+            'year' => 2026,
+        ]);
+
+        $this->assertEquals('inquiry', $engagement->fresh()->stage);
+    }
+
+    public function test_it_belongs_to_a_prospect()
+    {
+        $engagement = factory(ProspectEngagement::class)->create();
+
+        $this->assertInstanceOf(Prospect::class, $engagement->prospect);
+    }
+
+    public function test_a_prospect_has_many_engagements()
+    {
+        $prospect = factory(Prospect::class)->create();
+        factory(ProspectEngagement::class)->create(['prospect_id' => $prospect->id]);
+        factory(ProspectEngagement::class)->create(['prospect_id' => $prospect->id]);
+
+        $this->assertCount(2, $prospect->fresh()->engagements);
+    }
+
+    public function test_drift_flag_casts_to_boolean()
+    {
+        $engagement = factory(ProspectEngagement::class)->create(['drift_flag' => true]);
+
+        $this->assertTrue($engagement->fresh()->drift_flag);
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
         - Modules/Invoice/Entities/Invoice.php  # Ignore Error occurring due to Encryptable Trait
         - Modules/*/vendor/composer/ClassLoader.php
         - Modules/*/Database/Factories/*.php   # Ignore Error occurring due to Laravel factories
+        - Modules/*/Database/factories/*.php   # Ignore Error occurring due to Laravel factories (lowercase dir, case-sensitive on CI)
         - Modules/*/Database/Seeders/*.php   # Ignore Error occurring due to Laravel factories
         - Modules/*/Database/Seeders/*.php   # Ignore Error occurring due to Laravel factories
         - Modules/*/Tests/*.php   # Ignore Error occurring due to Laravel factories


### PR DESCRIPTION
## Why
Adds the pre-sales engagement state machine the portal never modeled — one prospect has many engagements over time (e.g. IDH cotton + IDH website), each moving through stages inquiry → … → won/lost/dropped, optionally linking to a project on Won.

This is the first step of connecting our AI tooling to the portal database (business-flow visibility): a separate, minimal service will map this table as a read/write model so engagement state can be reported on and advanced. Per ownership-by-domain, this is a Laravel-owned domain table created here; the AI service's own plumbing tables are created by that service, not in this PR.

## What
- `prospect_engagements` table (migration) + `ProspectEngagement` model
- `Prospect::engagements()` relationship
- `ProspectFactory` (new) + `ProspectEngagementFactory`
- Feature tests: persistence, default stage, relationships, boolean cast (5 tests, all green)

## Scope
Additive only. No existing tables, observers, or screens are touched. FK widths match targets (`owner_user_id` is unsigned INT to match `users.id`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prospect engagement tracking: record multiple engagements per prospect, track stages/dates, assign owners, note next actions, mark drift, and manage closure information.

* **Tests**
  * Added comprehensive test coverage verifying persistence, default stage, relationships, and flag casting for prospect engagements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColoredCow/portal/pull/3847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->