### PR TITLE
docs: note coloredcow-os-platform shares this database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,13 @@ Uses **Spatie Laravel Permission** for role-based access control (RBAC). Authori
 - **owen-it/laravel-auditing** — Model change auditing
 - **Maatwebsite Excel** — Spreadsheet import/export
 
+## Shared database — `coloredcow-os-platform` (MCP service)
+
+A separate service, [`coloredcow-os-platform`](https://github.com/ColoredCow/coloredcow-os-platform), connects to **this same MySQL database** to expose portal data to Claude over MCP (reads + structured writes), authenticated via Google sign-in. It is decoupled from this codebase but shares the database, so two things matter when working here:
+
+- **`osp_*` tables belong to that service.** It creates and owns `osp_audits` and `osp_oauth_kv` (plus its own `django_migrations`) via its own migrations — Laravel does **not** manage them. Don't treat them as orphans or drop them; they're not part of any Laravel migration. (And never run `php artisan migrate:fresh` against a shared/production database — it would drop them along with everything else.)
+- **Flag schema changes to the shared tables.** That service reads/writes a fixed set of existing tables: `prospects`, `prospect_comments`, `prospect_insights`, `clients`, `projects`, `invoices`, `users`. If a migration here **renames, drops, or restructures columns** on any of those, note it in the PR so the platform's data models can be updated in lockstep — otherwise its read/write tools break silently. Additive changes (new columns) are safe.
+
 ## Branch Naming Convention
 
 - `feature/{issue-id}/{description}` — New features (base: `develop`)


### PR DESCRIPTION
## Why
A new service, [coloredcow-os-platform](https://github.com/ColoredCow/coloredcow-os-platform), connects to **this same MySQL database** to expose portal data to Claude over MCP (reads + structured writes, gated to portal users and audited). It's decoupled from this codebase but shares the DB, so future work here should be aware of two things.

## What
Docs only — one new section in `CLAUDE.md`. **No code or schema change.**

1. **`osp_*` tables belong to that service** — `osp_audits`, `osp_oauth_kv` (+ its own `django_migrations`) are created/owned by the platform's migrations, not Laravel. Don't drop them; never `migrate:fresh` on prod.
2. **Flag schema changes to shared tables** — if a migration renames/drops/restructures columns on `prospects`, `prospect_comments`, `prospect_insights`, `clients`, `projects`, `invoices`, or `users`, note it in the PR so the platform's models stay in sync. Additive changes are safe.

No functional impact on the portal; the platform needs no portal code change to operate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer documentation regarding shared database management practices and contributor guidelines for schema modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->