### PR TITLE
feat(prospect): prospect.view/create/update permissions

### DIFF
--- a/database/Seeders/DatabaseSeeder.php
+++ b/database/Seeders/DatabaseSeeder.php
@@ -26,6 +26,7 @@ class DatabaseSeeder extends Seeder
         $this->call(HrDesignationTableSeeder::class);
         $this->call(UserDatabaseSeeder::class);
         $this->call(BooksPermissionsSeeder::class);
+        $this->call(ProspectPermissionsSeeder::class);
         $this->call(BookCategoriesTableSeeder::class);
         $this->call(ReportDatabaseSeeder::class);
 

--- a/database/Seeders/ProspectPermissionsSeeder.php
+++ b/database/Seeders/ProspectPermissionsSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+class ProspectPermissionsSeeder extends Seeder
+{
+    /**
+     * Seed the Prospect module permissions.
+     *
+     * These permissions gate prospect access. The os-platform MCP service checks
+     * them (via the Spatie model) before exposing prospect read/write tools to a
+     * user, and they are available for the portal's own gating. Roles are assigned
+     * through the role-management UI; `admin` is granted here as a sensible default,
+     * and `super-admin` bypasses all permission checks (see AuthServiceProvider).
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Artisan::call('permission:cache-reset');
+
+        $prospectPermissions = [
+            ['name' => 'prospect.view'],
+            ['name' => 'prospect.create'],
+            ['name' => 'prospect.update'],
+        ];
+
+        foreach ($prospectPermissions as $permission) {
+            Permission::updateOrCreate($permission);
+        }
+
+        // Grant to admin as a sensible default. Assign to any other role
+        // (e.g. employee, or a future sales role) via the role-management UI.
+        $adminRole = Role::where(['name' => 'admin'])->first();
+        if ($adminRole) {
+            foreach ($prospectPermissions as $permission) {
+                $adminRole->givePermissionTo($permission['name']);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why
Prospects have no permissions today — anyone logged in can manage them. This registers permissions so prospect access can be role-controlled.

Immediate driver: a new internal service (coloredcow-os-platform) lets Claude read/write prospects over MCP, and it gates every tool on a Spatie permission — these are the permissions it checks (resolved through whatever roles a user has; super-admin bypasses, per `AuthServiceProvider`). They're equally available for the portal's own gating. This is the first module in a broader move to permission-based access across the platform.

## What
- New `ProspectPermissionsSeeder` registers `prospect.view`, `prospect.create`, `prospect.update` via idempotent `Permission::updateOrCreate(...)`, following the `BooksPermissionsSeeder` pattern.
- Grants the three to the `admin` role as a sensible default.
- Wired into `DatabaseSeeder` (after `BooksPermissionsSeeder`; `RolesTableSeeder` already runs first, so `admin` exists).

## Notes
- **No schema change.** Soft-delete was intentionally dropped, so there's no `deleted_at`/migration and no `prospect.delete` permission.
- **Role assignment is via the role-management UI** — assign these to `employee` or any other role per leadership. Only `admin` is seeded by default; `super-admin` already bypasses all checks.
- `DatabaseSeeder` is gated to non-prod, so on production run: `php artisan db:seed --class='Database\Seeders\ProspectPermissionsSeeder'` (idempotent).
- Verified locally: the three permissions exist and `admin` has them.