### PR TITLE
fix(efforttracking): log swallowed errors during effort sheet sync

### DIFF
--- a/Modules/EffortTracking/Services/EffortTrackingService.php
+++ b/Modules/EffortTracking/Services/EffortTrackingService.php
@@ -5,6 +5,7 @@ namespace Modules\EffortTracking\Services;
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Exception;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Modules\Project\Entities\Project;
 use Modules\Project\Entities\ProjectMeta;
@@ -184,6 +185,10 @@ class EffortTrackingService
             $effortSheetUrl = $project->effort_sheet_url ?: $project->client->effort_sheet_url;
 
             if (! $effortSheetUrl) {
+                Log::warning('Effortsheet sync skipped: no effort sheet URL on project or client', [
+                    'project_id' => $project->id,
+                ]);
+
                 return false;
             }
 
@@ -192,6 +197,11 @@ class EffortTrackingService
             $isSyntaxMatching = preg_match('/.*[^-\w]([-\w]{25,})[^-\w]?.*/', $effortSheetUrl, $correctedEffortsheetUrl);
 
             if (! $isSyntaxMatching) {
+                Log::warning('Effortsheet sync failed: could not parse a sheet ID from the effort sheet URL', [
+                    'project_id' => $project->id,
+                    'effort_sheet_url' => $effortSheetUrl,
+                ]);
+
                 return false;
             }
 
@@ -242,6 +252,13 @@ class EffortTrackingService
                     break;
                 }
             } catch (Exception $e) {
+                Log::error('Effortsheet sync failed while scanning the sheet header columns', [
+                    'project_id' => $project->id,
+                    'sheet_id' => $sheetId,
+                    'exception' => $e->getMessage(),
+                    'at' => $e->getFile() . ':' . $e->getLine(),
+                ]);
+
                 return false;
             }
 
@@ -255,6 +272,20 @@ class EffortTrackingService
             $sheetIndexForEndDate = $this->getColumnIndex($sheetColumnsName['end_date'], $sheet[0]);
 
             if ($sheetIndexForTeamMemberName === false || $sheetIndexForTotalBillableEffort === false || $sheetIndexForStartDate === false || $sheetIndexForEndDate === false || $sheetIndexForTotalActualEffort === false) {
+                $missingColumns = array_keys(array_filter([
+                    'team_member_name' => $sheetIndexForTeamMemberName === false,
+                    'billable_effort' => $sheetIndexForTotalBillableEffort === false,
+                    'actual_effort' => $sheetIndexForTotalActualEffort === false,
+                    'start_date' => $sheetIndexForStartDate === false,
+                    'end_date' => $sheetIndexForEndDate === false,
+                ]));
+                Log::warning('Effortsheet sync failed: required column header(s) not found in the sheet', [
+                    'project_id' => $project->id,
+                    'missing_columns' => $missingColumns,
+                    'expected_column_names' => $sheetColumnsName,
+                    'headers_found' => $sheet[0] ?? [],
+                ]);
+
                 return false;
             }
 
@@ -272,6 +303,14 @@ class EffortTrackingService
                     ->range($range)
                     ->get();
             } catch (Exception $e) {
+                Log::error('Effortsheet sync failed while fetching team member rows from the sheet', [
+                    'project_id' => $project->id,
+                    'sheet_id' => $sheetId,
+                    'range' => $range,
+                    'exception' => $e->getMessage(),
+                    'at' => $e->getFile() . ':' . $e->getLine(),
+                ]);
+
                 return false;
             }
 
@@ -324,14 +363,36 @@ class EffortTrackingService
                                 ]
                             );
                         } catch (Exception $e) {
+                            Log::warning('Effortsheet sync: skipped updating effort for a user on a (sub)project', [
+                                'project_id' => $project->id,
+                                'sub_project' => $sheetProject['name'] ?? null,
+                                'user_nickname' => $userNickname ?? null,
+                                'exception' => $e->getMessage(),
+                                'at' => $e->getFile() . ':' . $e->getLine(),
+                            ]);
+
                             continue;
                         }
                     }
                 } catch (Exception $e) {
+                    Log::warning('Effortsheet sync: skipped a team member row', [
+                        'project_id' => $project->id,
+                        'user_nickname' => $userNickname ?? null,
+                        'exception' => $e->getMessage(),
+                        'at' => $e->getFile() . ':' . $e->getLine(),
+                    ]);
+
                     continue;
                 }
             }
         } catch (Exception $e) {
+            Log::error('Effortsheet sync failed', [
+                'project_id' => $project->id,
+                'exception' => $e->getMessage(),
+                'at' => $e->getFile() . ':' . $e->getLine(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
             return false;
         }
 


### PR DESCRIPTION
## Why

Syncing the effort sheet for one project fails with the red toast *"Something went wrong! Please check if the effortsheet formatting is correct."*, while another project syncs fine — and **nothing shows up in `storage/logs/laravel.log`**, making it impossible to diagnose.

Root cause of the *invisibility* (not the sync bug itself — that's next): the error is destroyed at three layers.

1. **Service swallows every exception.** [`EffortTrackingService::getEffortForProject()`](Modules/EffortTracking/Services/EffortTrackingService.php#L180) wraps the whole sync in try/catch and does `catch (Exception $e) { return false; }` — `$e` is captured but **never logged** (5 places). It also returns a bare `false` for "format" problems with no message: no sheet URL, unparseable sheet ID, or a missing/renamed **column header**.
2. **Controller flattens it.** [`EffortTrackingController@getEffortForProject`](Modules/EffortTracking/Http/Controllers/EffortTrackingController.php#L42) turns `false` into a generic `404 {"message":"Error occurred"}` — no detail, because the service gave it none.
3. **Frontend ignores even that.** [`app.js`](Modules/Project/Resources/assets/js/app.js#L50) discards the response and shows a hardcoded toast.

So the real reason never reaches the logs, the HTTP response, or the browser console.

## What this does

Adds `Log::warning` / `Log::error` at **every** failure point in `getEffortForProject()`, each naming the stage and carrying `project_id`, the exception message + `file:line`, and — for the column-header gate — the **expected vs. actual sheet headers** and exactly which columns are missing.

Failure points instrumented:
- No effort sheet URL on project/client
- Sheet ID not parseable from the URL
- Exception while scanning header columns
- Required column header(s) not found *(prime suspect — `getColumnIndex` matches on trim+lowercase, so a renamed/extra-spaced/reordered header fails here)*
- Exception while fetching team-member rows from the sheet *(e.g. Google API permission on that specific sheet)*
- Per-(sub)project effort update skipped for a user
- A team-member row skipped
- Outermost catch-all (includes stack trace)

**Purely additive** — no control flow or return values change.

## How to use it to find the bug

```sh
tail -f storage/logs/laravel.log
```
…then click **Sync** on the failing project. The log line names exactly which gate fired and why (and for the column case, shows the headers it actually read vs. what it expected).

## Notes
- No schema/migration changes — shared `osp_*`/platform tables unaffected.
- The actual root-cause fix for the failing project will be a follow-up once these logs reveal the cause. We can also decide then whether to surface the real reason to the user (controller + toast) instead of the generic message.
- Verified locally: `php -l` clean, PHP-CS-Fixer reports no changes. No existing tests exercise this method; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error tracking and diagnostic logging for effort sheet synchronization to improve troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->