### PR TITLE
fix(project): restore fixed-budget project KAM reminder (undefined-method crash)

### DIFF
--- a/Modules/Project/Services/ProjectService.php
+++ b/Modules/Project/Services/ProjectService.php
@@ -248,6 +248,26 @@ class ProjectService implements ProjectServiceContract
         return $projectsData;
     }
 
+    public function getMailForFixedBudgetProjectKeyAccountManagers()
+    {
+        $reminderDate = Carbon::today(config('constants.timezone.indian'))->addDays(5);
+        $projects = Project::whereType('fixed-budget')->whereStatus('active')->whereDate('end_date', $reminderDate)->get();
+        $keyAccountManagersDetails = [];
+        foreach ($projects as $project) {
+            $user = $project->client->keyAccountManager;
+            if ($user) {
+                $keyAccountManagersDetails[$user->id][] = [
+                    'project' => $project,
+                    'email' => $user->email,
+                    'end date' => $project->end_date,
+                    'name' => $user->name,
+                ];
+            }
+        }
+
+        return $keyAccountManagersDetails;
+    }
+
     public function getMailDetailsForZeroExpectedHours()
     {
         $zeroEffortProjectsIds = ProjectTeamMember::where('daily_expected_effort', 0)->pluck('project_id');

--- a/Modules/Project/Tests/Feature/FixedBudgetProjectCommandTest.php
+++ b/Modules/Project/Tests/Feature/FixedBudgetProjectCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\Project\Tests\Feature;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Modules\Client\Entities\Client;
+use Modules\Project\Emails\FixedBudgetProjectMail;
+use Modules\Project\Entities\Project;
+use Modules\User\Entities\User;
+use Tests\TestCase;
+
+class FixedBudgetProjectCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_queues_reminder_to_key_account_manager_for_fixed_budget_project_ending_in_five_days()
+    {
+        Mail::fake();
+
+        $kam = User::factory()->create();
+        $client = Client::factory()->create(['key_account_manager_id' => $kam->id]);
+        $project = Project::factory()->create([
+            'client_id' => $client->id,
+            'type' => 'fixed-budget',
+            'status' => 'active',
+            'end_date' => Carbon::today(config('constants.timezone.indian'))->addDays(5),
+        ]);
+
+        $this->artisan('project:fixed-budget-project')->assertExitCode(0);
+
+        Mail::assertQueued(FixedBudgetProjectMail::class, function ($mail) use ($kam, $project) {
+            return collect($mail->projectData)->contains(function ($row) use ($kam, $project) {
+                return $row['email'] === $kam->email
+                    && $row['project']->id === $project->id;
+            });
+        });
+    }
+
+    public function test_command_does_not_remind_for_fixed_budget_project_not_ending_in_five_days()
+    {
+        Mail::fake();
+
+        $kam = User::factory()->create();
+        $client = Client::factory()->create(['key_account_manager_id' => $kam->id]);
+        Project::factory()->create([
+            'client_id' => $client->id,
+            'type' => 'fixed-budget',
+            'status' => 'active',
+            'end_date' => Carbon::today(config('constants.timezone.indian'))->addDays(10),
+        ]);
+
+        $this->artisan('project:fixed-budget-project')->assertExitCode(0);
+
+        Mail::assertNotQueued(FixedBudgetProjectMail::class);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -59,7 +59,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('hr:message-for-email-verified')->dailyAt('7:00');
         $schedule->command('hr:send-job-expired-email-to-hr')->dailyAt('11:00');
         $schedule->command('mapping-of-jobs-and-hr-rounds');
-        $schedule->command('project:fixed-budget-project');
+        $schedule->command('project:fixed-budget-project')->dailyAt('09:00');
         $schedule->command('project:send-pending-delivery-report-reminder')->dailyAt('11:00');
         $schedule->command('invoice:send-unpaid-invoice-list')->weekly()->mondays()->at('09:00');
         $schedule->command('invoice:send-upcoming-invoice-list')->dailyAt('11:00');


### PR DESCRIPTION
## What & why

The scheduler was logging a fatal on every run:

> `production.ERROR: Call to undefined method Modules\Project\Services\ProjectService::getMailForFixedBudgetProjectKeyAccountManagers() at .../Modules/Project/Console/FixedBudgetProject.php:34`

The `project:fixed-budget-project` command — which reminds a project's key account manager that a **fixed-budget project is about to end** — called `ProjectService::getMailForFixedBudgetProjectKeyAccountManagers()`, but that method no longer existed. A prior merge-conflict resolution (`8edd32e1a "removed conflicts"`) dropped the method definition while leaving the caller in place. Result:

- the command crashed before queuing any mail → KAMs **never received the reminder**, and
- because the command is scheduled, production logged a fatal on **every** run.

## Changes

1. **Restore the missing method** `ProjectService::getMailForFixedBudgetProjectKeyAccountManagers()` — returns active `fixed-budget` projects whose `end_date` is 5 days out, grouped by KAM, with the exact array shape the mail view expects (`project`, `email`, `end date`, `name`).
   - Kept **separate** from `getMailDetailsForProjectKeyAccountManagers()`, which powers the distinct `project:ended-project` command (projects already past `end_date`). Reusing that method would have duplicated/altered ended-project behavior.
2. **Schedule cadence** — `project:fixed-budget-project` had no frequency chained, so Laravel defaulted it to **every minute**. With the crash fixed, that would email KAMs ~1440×/day on the trigger day. Set `->dailyAt('09:00')`, matching the sibling `project:ended-project`.

## Testing

New feature test `Modules/Project/Tests/Feature/FixedBudgetProjectCommandTest.php`:
- queues a reminder to the KAM for a fixed-budget project ending in 5 days, and
- does **not** remind for one ending in 10 days.

Verified red→green — the red failure was the exact production `Call to undefined method`. PHP-CS-Fixer reports 0 fixable files on the changed files.

```
OK (2 tests, 4 assertions)
```

## Notes for reviewer

- The restored method adds a `whereStatus('active')` filter, consistent with the sibling method; the pre-merge original lacked it. Flag if you want the looser original behavior.
- Restored "nearing" semantics = `end_date` exactly 5 days out, matching the command description and the mail subject ("…about to end"). Confirm the 5-day window is still desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
