### PR TITLE
fix: add "Applied for" job title to HR AI-evaluation copy

### DIFF
--- a/Modules/HR/Tests/Feature/CopyForAiEvaluationTest.php
+++ b/Modules/HR/Tests/Feature/CopyForAiEvaluationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Modules\HR\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\HR\Entities\Applicant;
+use Modules\HR\Entities\Application;
+use Modules\HR\Entities\Job;
+use Tests\TestCase;
+
+class CopyForAiEvaluationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_clipboard_text_includes_applied_for_job_title()
+    {
+        $applicant = Applicant::factory()->create(['name' => 'Jane Doe']);
+        $job = Job::factory()->create(['title' => 'Senior Laravel Developer']);
+        $application = Application::factory()->create([
+            'hr_applicant_id' => $applicant->id,
+            'hr_job_id' => $job->id,
+        ]);
+
+        $html = view('hr.application.copy-for-ai-evaluation', [
+            'applicant' => $applicant,
+            'application' => $application,
+        ])->render();
+
+        $this->assertStringContainsString('Applied for: ' . $job->title, $html);
+    }
+}

--- a/resources/views/hr/application/copy-for-ai-evaluation.blade.php
+++ b/resources/views/hr/application/copy-for-ai-evaluation.blade.php
@@ -3,6 +3,11 @@
     $clipboardLines[] = 'Candidate to evaluate:';
     $clipboardLines[] = $applicant->name . ', applied on ' . $application->created_at->format(config('constants.display_date_format'));
 
+    $appliedForJobTitle = optional($application->job)->title;
+    if (!empty($appliedForJobTitle)) {
+        $clipboardLines[] = 'Applied for: ' . $appliedForJobTitle;
+    }
+
     if (!empty($applicant->graduation_year)) {
         $clipboardLines[] = 'Graduation Year: ' . $applicant->graduation_year;
     }


### PR DESCRIPTION
## What

The **"Copy candidate details for AI evaluation"** button (used on the HR application **details** and **edit** pages) copies candidate details to the clipboard, but it omitted the **job the candidate applied for**.

This adds an `Applied for: <job title>` line to the copied text.

## Why

When evaluators paste the candidate details into an AI tool, the role the candidate applied for is essential context. It was missing, so they had to add it manually.

## Change

`resources/views/hr/application/copy-for-ai-evaluation.blade.php` — adds the job title right after the candidate name/applied-on line, mirroring the order shown on the application details page ("Name" → "Applied for").

Before:
```
Candidate to evaluate:
Jane Doe, applied on 14/06/2026
Graduation Year: 1988
```

After:
```
Candidate to evaluate:
Jane Doe, applied on 14/06/2026
Applied for: Senior Laravel Developer
Graduation Year: 1988
```

The job is read via `optional($application->job)->title`, so the line is safely skipped if no job is linked — no risk of a render error in production.

## Testing

- Added `Modules/HR/Tests/Feature/CopyForAiEvaluationTest.php` — renders the partial and asserts the clipboard text contains `Applied for: <job title>` (written test-first: confirmed it failed before the change, passes after).
- Regression check: `JobFilterTest` (6) and HR `ApplicantTest` (1) still pass.

## Hotfix note

Targeted at **`main`** for direct deployment to production. Change is isolated to one view partial plus a new test; no schema or shared-table changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)