### PR TITLE
chore(invoice): seed demo invoices + currency rates for local finance dev/testing

### DIFF
--- a/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
+++ b/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
@@ -45,21 +45,31 @@ class InvoiceDatabaseSeeder extends Seeder
             return;
         }
 
+        // Single source of truth for the demo's one foreign-currency client: the
+        // first client by id. Both the address backfill (which drives the symbol the
+        // UI shows) and the invoice rows (which set invoices.currency) key off this
+        // same id, so a USD invoice always renders a USD symbol.
+        $firstClient = DB::table('clients')->orderBy('id')->first();
+        if (! $firstClient) {
+            return; // no clients to attach demo finance data to
+        }
+        $usdClientId = (int) $firstClient->id;
+
         // The invoice UI derives an amount's currency symbol from the client's
         // address country (Client::getCountryAttribute), NOT from invoices.currency.
         // Base client seeding creates no addresses, so demo amounts render with no
         // currency. Backfill a billing address per client. This is idempotent and
         // runs before the invoices guard below, so re-running the seeder also fixes
         // a database that was seeded before this was added.
-        $this->seedClientAddresses();
+        $this->seedClientAddresses($usdClientId);
 
         if (DB::table('invoices')->exists()) {
             return;
         }
 
-        DB::transaction(function () {
+        DB::transaction(function () use ($usdClientId) {
             $this->seedCurrencyRates();
-            $this->seedInvoices();
+            $this->seedInvoices($usdClientId);
         });
     }
 
@@ -99,7 +109,7 @@ class InvoiceDatabaseSeeder extends Seeder
      * any client that already has an address, so it is safe to re-run and never
      * overwrites real local data.
      */
-    private function seedClientAddresses(): void
+    private function seedClientAddresses(int $usdClientId): void
     {
         $india = DB::table('countries')->where('currency', 'INR')->orderBy('id')->first();
         $usd = DB::table('countries')->where('currency', 'USD')->orderBy('id')->first();
@@ -107,13 +117,7 @@ class InvoiceDatabaseSeeder extends Seeder
             return; // countries not seeded on this database — nothing safe to map to
         }
 
-        $clients = DB::table('clients')->orderBy('id')->get();
-        if ($clients->isEmpty()) {
-            return;
-        }
-        $usdClientId = (int) $clients->first()->id;
-
-        foreach ($clients as $client) {
+        foreach (DB::table('clients')->orderBy('id')->get() as $client) {
             // Idempotent: never touch a client that already has an address.
             if (DB::table('client_addresses')->where('client_id', $client->id)->exists()) {
                 continue;
@@ -146,7 +150,7 @@ class InvoiceDatabaseSeeder extends Seeder
         DB::table('currency_avg_rate')->insert($rows);
     }
 
-    private function seedInvoices(): void
+    private function seedInvoices(int $usdClientId): void
     {
         $clients = DB::table('clients')->orderBy('id')->get();
         $projects = DB::table('projects')->orderBy('id')->get();
@@ -161,8 +165,9 @@ class InvoiceDatabaseSeeder extends Seeder
             ->groupBy('m.project_id')
             ->pluck('hours', 'm.project_id');
 
-        // Deterministic roles for the planted edge cases.
-        $usdClientId = (int) $clients->first()->id;                 // one foreign-currency client
+        // Deterministic roles for the planted edge cases. $usdClientId is passed in
+        // (computed once in run()) so these invoices and the address backfill agree
+        // on which client bills in a foreign currency.
         $leakerProjectId = (int) $projects->first()->id;            // a fixed-budget leaker
         $clientLevelClientId = (int) ($clients->count() > 1 ? $clients->values()->get(1)->id : $usdClientId);
 

--- a/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
+++ b/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
@@ -202,7 +202,7 @@ class InvoiceDatabaseSeeder extends Seeder
      * of a consumer's INR normalization:
      *   seq % 3 == 0 -> per-invoice sent_conversion_rate (encrypted)
      *   seq % 3 == 1 -> decimal conversion_rate (plain)
-     *   seq % 3 == 2 -> neither (forces the currency_avg_rate fallback)
+     *   seq % 3 == 2 -> neither (forces the currency_avg_rate fallback).
      */
     private function invoiceRow(int $seq, $clientId, $projectId, float $amountInr, bool $isUsd, array $overrides, bool $encrypt = true): array
     {

--- a/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
+++ b/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
@@ -44,6 +44,15 @@ class InvoiceDatabaseSeeder extends Seeder
         if (app()->environment('production')) {
             return;
         }
+
+        // The invoice UI derives an amount's currency symbol from the client's
+        // address country (Client::getCountryAttribute), NOT from invoices.currency.
+        // Base client seeding creates no addresses, so demo amounts render with no
+        // currency. Backfill a billing address per client. This is idempotent and
+        // runs before the invoices guard below, so re-running the seeder also fixes
+        // a database that was seeded before this was added.
+        $this->seedClientAddresses();
+
         if (DB::table('invoices')->exists()) {
             return;
         }
@@ -79,6 +88,43 @@ class InvoiceDatabaseSeeder extends Seeder
                 continue;
             }
             $role->givePermissionTo($permissions);
+        }
+    }
+
+    /**
+     * Give every client a billing address whose country fixes the currency the UI
+     * shows for its invoices — the symbol comes from client -> address -> country,
+     * not from invoices.currency. The first client (the demo's designated foreign-
+     * currency client) maps to a USD country; the rest map to India (INR). Skips
+     * any client that already has an address, so it is safe to re-run and never
+     * overwrites real local data.
+     */
+    private function seedClientAddresses(): void
+    {
+        $india = DB::table('countries')->where('currency', 'INR')->orderBy('id')->first();
+        $usd = DB::table('countries')->where('currency', 'USD')->orderBy('id')->first();
+        if (! $india || ! $usd) {
+            return; // countries not seeded on this database — nothing safe to map to
+        }
+
+        $clients = DB::table('clients')->orderBy('id')->get();
+        if ($clients->isEmpty()) {
+            return;
+        }
+        $usdClientId = (int) $clients->first()->id;
+
+        foreach ($clients as $client) {
+            // Idempotent: never touch a client that already has an address.
+            if (DB::table('client_addresses')->where('client_id', $client->id)->exists()) {
+                continue;
+            }
+            DB::table('client_addresses')->insert([
+                'client_id' => $client->id,
+                'country_id' => ((int) $client->id === $usdClientId) ? $usd->id : $india->id,
+                'type' => 'billing-address',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
         }
     }
 

--- a/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
+++ b/Modules/Invoice/Database/Seeders/InvoiceDatabaseSeeder.php
@@ -2,55 +2,260 @@
 
 namespace Modules\Invoice\Database\Seeders;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
+/**
+ * Seeds the finance_invoices.* permissions AND a graph of demo invoices +
+ * currency rates on top of the existing client/project/effort graph, so a
+ * downstream read-only finance view can be built and verified locally.
+ *
+ * Runnable standalone, additively, without a full re-seed:
+ *   php artisan db:seed --class="Modules\Invoice\Database\Seeders\InvoiceDatabaseSeeder"
+ *
+ * Amounts are inserted via the query builder (DB::table) but the encryptable
+ * columns (`amount`, `amount_paid`, `sent_conversion_rate`) are wrapped in
+ * Crypt::encrypt() — the SAME encryption the Invoice model's Encryptable trait
+ * applies — so the seeded data matches how production stores it (AES-256-CBC,
+ * serialized). `conversion_rate` (decimal) is NOT encryptable and stays plain.
+ * A few legacy rows are stored as plaintext to mirror pre-Encryptable data and
+ * exercise a consumer's decrypt-else-use-raw path.
+ */
 class InvoiceDatabaseSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
+    /** Blended cost rate + USD->INR, mirroring the finance v1 assumptions (ADR-15). */
+    const COST_RATE_USD = 50;
+    const USD_INR = 83.0;
+
     public function run()
     {
         Model::unguard();
 
-        $financeInvoicesPermissions = [
-            ['name' => 'finance_invoices.create'],
-            ['name' => 'finance_invoices.view'],
-            ['name' => 'finance_invoices.update'],
-            ['name' => 'finance_invoices.delete'],
+        $this->seedPermissions();
+
+        // Demo DATA only outside production, and only when there are no invoices
+        // yet — idempotent and non-destructive, so it is safe to run on top of an
+        // existing local database.
+        if (app()->environment('production')) {
+            return;
+        }
+        if (DB::table('invoices')->exists()) {
+            return;
+        }
+
+        DB::transaction(function () {
+            $this->seedCurrencyRates();
+            $this->seedInvoices();
+        });
+    }
+
+    private function seedPermissions(): void
+    {
+        $permissions = [
+            'finance_invoices.create',
+            'finance_invoices.view',
+            'finance_invoices.update',
+            'finance_invoices.delete',
+            'finance_invoices_settings.create',
+            'finance_invoices_settings.view',
+            'finance_invoices_settings.update',
+            'finance_invoices_settings.delete',
         ];
 
-        $financeInvoicesSettingsPermissions = [
-            ['name' => 'finance_invoices_settings.create'],
-            ['name' => 'finance_invoices_settings.view'],
-            ['name' => 'finance_invoices_settings.update'],
-            ['name' => 'finance_invoices_settings.delete'],
+        foreach ($permissions as $name) {
+            Permission::updateOrCreate(['name' => $name]);
+        }
+
+        // Grant to admin + finance-manager when present. Null-guarded so a
+        // standalone run can't crash if a role isn't seeded on this database.
+        foreach (['admin', 'finance-manager'] as $roleName) {
+            $role = Role::where('name', $roleName)->first();
+            if (! $role) {
+                continue;
+            }
+            $role->givePermissionTo($permissions);
+        }
+    }
+
+    private function seedCurrencyRates(): void
+    {
+        // USD averages for the last 6 months + current month, so INR normalization
+        // has a fallback even for foreign invoices that carry no per-invoice rate.
+        $rows = [];
+        for ($i = 6; $i >= 0; $i--) {
+            $month = Carbon::today()->startOfMonth()->subMonths($i);
+            $rows[] = [
+                'currency' => 'USD',
+                'captured_for' => $month->toDateString(),
+                'avg_rate' => self::USD_INR + (($i % 3) - 1), // ~82-84
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        }
+        DB::table('currency_avg_rate')->insert($rows);
+    }
+
+    private function seedInvoices(): void
+    {
+        $clients = DB::table('clients')->orderBy('id')->get();
+        $projects = DB::table('projects')->orderBy('id')->get();
+        if ($clients->isEmpty() || $projects->isEmpty()) {
+            return; // nothing to attach to
+        }
+
+        // billed hours per project = SUM(actual_effort) (per-project, ADR-14) — the cost input.
+        $billedByProject = DB::table('project_team_members_effort as e')
+            ->join('project_team_members as m', 'm.id', '=', 'e.project_team_member_id')
+            ->select('m.project_id', DB::raw('SUM(e.actual_effort) as hours'))
+            ->groupBy('m.project_id')
+            ->pluck('hours', 'm.project_id');
+
+        // Deterministic roles for the planted edge cases.
+        $usdClientId = (int) $clients->first()->id;                 // one foreign-currency client
+        $leakerProjectId = (int) $projects->first()->id;            // a fixed-budget leaker
+        $clientLevelClientId = (int) ($clients->count() > 1 ? $clients->values()->get(1)->id : $usdClientId);
+
+        // Make the leaker a fixed-budget project (narrative realism; leakage itself
+        // is just cost > revenue, which the small invoice below guarantees).
+        DB::table('projects')->where('id', $leakerProjectId)->update(['type' => 'fixed-budget']);
+
+        $rows = [];
+        $seq = 1;
+
+        // 1) One current-month, project-level invoice per project (revenue for margin),
+        //    sized as a multiple of that project's effort-cost so the sign is deterministic.
+        foreach ($projects as $i => $project) {
+            $isUsd = ((int) $project->client_id === $usdClientId);
+            $costInr = (float) ($billedByProject[$project->id] ?? 0) * self::COST_RATE_USD * self::USD_INR;
+
+            if ((int) $project->id === $leakerProjectId) {
+                $factor = 0.4;                       // leaker: revenue well below cost
+            } elseif ($i === 1) {
+                $factor = 1.6;                       // clearly healthy
+            } else {
+                $factor = 0.9 + (($i % 4) * 0.15);   // mixed 0.90 .. 1.35
+            }
+            $targetInr = max(50000.0, round($costInr * $factor, -2));
+
+            $rows[] = $this->invoiceRow($seq++, $project->client_id, $project->id, $targetInr, $isUsd, [
+                'sent_on' => Carbon::today()->startOfMonth()->addDays(3)->toDateString(),
+                'due_on' => Carbon::today()->startOfMonth()->addDays(33)->toDateString(),
+            ]);
+        }
+
+        // 2) Receivables / aging: unpaid invoices across buckets for the first two clients.
+        foreach ($clients->take(2) as $client) {
+            $proj = $projects->firstWhere('client_id', $client->id);
+            $isUsd = ((int) $client->id === $usdClientId);
+            foreach ([15, 45, 75, 120] as $daysPastDue) {
+                $rows[] = $this->invoiceRow($seq++, $client->id, optional($proj)->id, 80000.0 + $daysPastDue * 1000, $isUsd, [
+                    'sent_on' => Carbon::today()->subDays($daysPastDue + 30)->toDateString(),
+                    'due_on' => Carbon::today()->subDays($daysPastDue)->toDateString(),
+                ]);
+            }
+        }
+
+        // 3) A couple of PAID invoices (collected) for contrast with the unpaid ones.
+        foreach ($clients->take(2) as $client) {
+            $proj = $projects->firstWhere('client_id', $client->id);
+            $isUsd = ((int) $client->id === $usdClientId);
+            $rows[] = $this->invoiceRow($seq++, $client->id, optional($proj)->id, 120000.0, $isUsd, [
+                'sent_on' => Carbon::today()->subDays(80)->toDateString(),
+                'due_on' => Carbon::today()->subDays(50)->toDateString(),
+                'payment_at' => Carbon::today()->subDays(55)->toDateString(),
+                'status' => 'paid',
+            ]);
+        }
+
+        // 4) One CLIENT-LEVEL invoice (project_id NULL) to exercise the billing_level split.
+        $rows[] = $this->invoiceRow($seq++, $clientLevelClientId, null, 250000.0, $clientLevelClientId === $usdClientId, [
+            'billing_level' => 'client',
+            'sent_on' => Carbon::today()->startOfMonth()->addDays(5)->toDateString(),
+            'due_on' => Carbon::today()->startOfMonth()->addDays(35)->toDateString(),
+        ]);
+
+        // 5) A couple of LEGACY plaintext invoices (pre-Encryptable era), stored
+        //    unencrypted to mirror prod's mixed data and exercise a consumer's
+        //    decrypt-else-use-raw path.
+        foreach ($clients->slice(2, 2) as $client) {
+            $proj = $projects->firstWhere('client_id', $client->id);
+            $rows[] = $this->invoiceRow($seq++, $client->id, optional($proj)->id, 90000.0, false, [
+                'sent_on' => Carbon::today()->subDays(200)->toDateString(),
+                'due_on' => Carbon::today()->subDays(170)->toDateString(),
+            ], false);
+        }
+
+        DB::table('invoices')->insert($rows);
+    }
+
+    /**
+     * Build one invoice row. The encryptable columns (amount / amount_paid /
+     * sent_conversion_rate) are Crypt::encrypt()ed when $encrypt is true (the
+     * default — matching how the Invoice model writes production data); legacy
+     * rows pass $encrypt = false to store plaintext. For the USD client the amount
+     * is stored in USD and the rate is carried three ways to exercise each branch
+     * of a consumer's INR normalization:
+     *   seq % 3 == 0 -> per-invoice sent_conversion_rate (encrypted)
+     *   seq % 3 == 1 -> decimal conversion_rate (plain)
+     *   seq % 3 == 2 -> neither (forces the currency_avg_rate fallback)
+     */
+    private function invoiceRow(int $seq, $clientId, $projectId, float $amountInr, bool $isUsd, array $overrides, bool $encrypt = true): array
+    {
+        $currency = $isUsd ? 'USD' : 'INR';
+        $amount = $isUsd ? round($amountInr / self::USD_INR, 2) : round($amountInr, 2);
+
+        $sentRate = null;
+        $convRate = null;
+        if ($isUsd) {
+            $mode = $seq % 3;
+            if ($mode === 0) {
+                $sentRate = self::USD_INR;
+            } elseif ($mode === 1) {
+                $convRate = self::USD_INR;
+            }
+        }
+
+        // Encrypt the encryptable columns exactly as the Invoice model would, so the
+        // seeded rows are byte-for-byte the shape production stores. conversion_rate
+        // is a plain decimal column (not encryptable) and is never wrapped.
+        $enc = fn ($v) => $v === null ? null : ($encrypt ? Crypt::encrypt((string) $v) : (string) $v);
+
+        $base = [
+            'invoice_number' => sprintf('INV-DEMO-%04d', $seq),
+            'client_id' => $clientId,
+            'project_id' => $projectId,
+            'billing_level' => 'project',
+            'currency' => $currency,
+            'amount' => $enc($amount),
+            'amount_paid' => null,
+            'sent_conversion_rate' => $enc($sentRate),
+            'conversion_rate' => $convRate,
+            'status' => 'sent',
+            'sent_on' => Carbon::today()->toDateString(),
+            'due_on' => Carbon::today()->addDays(30)->toDateString(),
+            'receivable_date' => null,
+            'payment_at' => null,
+            'reminder_mail_count' => 0,
+            'payment_confirmation_mail_sent' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
         ];
 
-        $allfinanceInvoicePermissions = array_merge(
-            $financeInvoicesPermissions,
-            $financeInvoicesSettingsPermissions
-        );
+        $row = array_merge($base, $overrides);
 
-        foreach ($allfinanceInvoicePermissions as $permission) {
-            Permission::updateOrCreate($permission);
+        // receivable_date mirrors due_on (as InvoiceService::store does).
+        $row['receivable_date'] = $row['receivable_date'] ?? $row['due_on'];
+
+        // a paid invoice has amount_paid = amount (encrypted to match).
+        if (! empty($row['payment_at']) && empty($row['amount_paid'])) {
+            $row['amount_paid'] = $enc($amount);
         }
 
-        // set permissions for admin role
-        $adminRole = Role::where(['name' => 'admin'])->first();
-        foreach ($allfinanceInvoicePermissions as $permission) {
-            $adminRole->givePermissionTo($permission);
-        }
-
-        // set permissions for finance-manager role
-        $financeManagerRole = Role::where(['name' => 'finance-manager'])->first();
-        foreach ($allfinanceInvoicePermissions as $permission) {
-            $financeManagerRole->givePermissionTo($permission);
-        }
+        return $row;
     }
 }

--- a/database/Seeders/DatabaseSeeder.php
+++ b/database/Seeders/DatabaseSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use Modules\Client\Database\Seeders\ClientDatabaseSeeder;
 use Modules\HR\Database\Seeders\HrDesignationTableSeeder;
 use Modules\HR\Database\Seeders\HrDomainTableSeeder;
+use Modules\Invoice\Database\Seeders\InvoiceDatabaseSeeder;
 use Modules\Project\Database\Seeders\ProjectDatabaseSeeder;
 use Modules\Report\Database\Seeders\ReportDatabaseSeeder;
 
@@ -33,6 +34,7 @@ class DatabaseSeeder extends Seeder
         $this->call(ReportDatabaseSeeder::class);
         $this->call(ClientDatabaseSeeder::class);
         $this->call(ProjectDatabaseSeeder::class);
+        $this->call(InvoiceDatabaseSeeder::class);
 
         return true;
     }


### PR DESCRIPTION
## What

Adds local **finance dev data** so a downstream read-only finance view (invoice register / collections / per-client & per-project margin) can be built and verified against realistic invoices. Today a fresh `db:seed` produces clients/projects/effort but **no invoices, no FX rates**, and the `finance_invoices.*` permissions aren't seeded at all — the existing `InvoiceDatabaseSeeder` only defined permissions and **was never called** by the main `DatabaseSeeder`.

## How to use (additive — no `migrate:fresh`, no full re-seed)

```bash
php artisan db:seed --class="Modules\Invoice\Database\Seeders\InvoiceDatabaseSeeder"
```

Runs on top of the existing graph, **idempotent** (skips when invoices already exist), guarded off production. Also wired into `DatabaseSeeder` (after `ProjectDatabaseSeeder`) so fresh setups get it. To re-seed during development, clear invoices first (e.g. `DB::table('invoices')->delete()`).

## What it seeds (attached to the existing client / project / effort graph)

- `finance_invoices.*` permissions → granted to `admin` + `finance-manager` (null-guarded against a missing role).
- ~23 invoices covering the cases a finance view needs: a **USD client** (currency→INR), unpaid invoices across **aging buckets** (15 / 45 / 75 / 120 days overdue), **paid** invoices, both **project-** and **client-level** billing (NULL `project_id`), one **fixed-budget "leaker"** (cost > revenue) and one clearly **healthy** project, plus a couple of **legacy plaintext** rows.
- `currency_avg_rate` USD rows (last 6 months + current) for currency-normalization.

## Encryption — matches production

The encryptable columns (`amount`, `amount_paid`, `sent_conversion_rate`) are written with **`Crypt::encrypt()`** — the same encryption the `Invoice` model's `Encryptable` trait applies — so seeded rows are the shape prod stores (AES-256-CBC, serialized). `conversion_rate` (decimal) isn't encryptable and stays plain. A couple of **legacy plaintext** rows mirror pre-`Encryptable` data so a consumer's decrypt-else-use-raw path is exercised.

## Verified locally

Seeded additively (→ 23 invoices); re-run is a no-op. `amount` stored as ciphertext (`eyJpdi…`) and decrypts back correctly; legacy rows stay plaintext; scoped to the current month the leaker shows negative margin (cost ≈ ₹914k vs revenue ≈ ₹366k) and the healthy project positive; `admin` holds `finance_invoices.view`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved demo invoice seeding to be deterministic and idempotent, preventing duplicate records and avoiding seeding changes in production or when invoice data already exists.
  * Added realistic demo currency-rate history and a wider range of invoice scenarios (unpaid receivables across aging buckets, paid invoices, and mixed project/client cases).
  * Refreshed finance permission seeding to reliably create/update required permissions and assign them to available admin and finance-manager roles.
  * Ensured invoice demo creation runs safely as a single database transaction and includes legacy-style entries where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->